### PR TITLE
Add OIDC login_hint

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -2,9 +2,9 @@ import { env } from '$env/dynamic/public';
 
 import * as Api from '$lib/openapi/server';
 import { removeCredentials } from '$lib/credentials.js';
-import { ToastSettings } from '@skeletonlabs/skeleton';
+import type { ToastSettings } from '@skeletonlabs/skeleton';
 
-import { ROOT_CONTEXT, defaultTextMapSetter, propagation, trace } from '@opentelemetry/api';
+import { ROOT_CONTEXT, defaultTextMapSetter, trace } from '@opentelemetry/api';
 import type { Span } from '@opentelemetry/api';
 import { W3CTraceContextPropagator } from '@opentelemetry/core';
 

--- a/src/lib/credentials.js
+++ b/src/lib/credentials.js
@@ -4,27 +4,29 @@ import { sessionStorage } from '$lib/sessionStorage.js';
 // token is the authorization bearer token for making API requests.
 export const token = sessionStorage('token');
 
-// email is the user's email address.
-export const email = sessionStorage('email');
-
-// region is the currently selected region.
-// TODO: make this use persistent storage.
-export const region = writable('region');
+// idToken is the user's idToken and contains OIDC information about them.
+export const profile = sessionStorage('id_token');
 
 // This is called when the initial access token is acquired from the oauth
 // exchange.  It uses the token to rescope to a project, that's either selected
 // from persistent storage, and as a fallback, just selects the first one the
 // user has access too as a default.
-export function setCredentials(accessToken, emailAddress) {
+export function setCredentials(accessToken, idToken) {
 	// Set everything else up first, then update the token.
 	// Everything should hang off the presence of a token, so we expect the
 	// other details to be ready to be consumed by that point.
-	email.set(emailAddress);
+	profile.set(idToken);
 	token.set(accessToken);
 }
 
 // Remove credentials i.e. on token expiry.
+// It retains the ID token information for a login hint.
 export function removeCredentials() {
 	token.set(null);
-	email.set(null);
+}
+
+// Fully logs out and forgets everything about a user.
+export function logout() {
+	token.set(null);
+	profile.set(null);
 }

--- a/src/lib/shell/ShellAppBar.svelte
+++ b/src/lib/shell/ShellAppBar.svelte
@@ -12,16 +12,22 @@
 		drawerStore.open(settings);
 	}
 
-	import { email, removeCredentials } from '$lib/credentials.js';
+	import { profile, logout } from '$lib/credentials.js';
 
 	let emailAddress: string;
 
-	email.subscribe((email) => {
-		emailAddress = email;
+	profile.subscribe((value) => {
+		if (!value) {
+			emailAddress = null;
+			return;
+		}
+
+		const claims = JSON.parse(value);
+		emailAddress = claims.email;
 	});
 
-	function logout(): void {
-		removeCredentials();
+	function doLogout(): void {
+		logout();
 	}
 </script>
 
@@ -55,7 +61,7 @@
 
 				<section class="flex justify-between items-center">
 					<h6 class="h6">Logout</h6>
-					<button class="btn p-0 text-2xl" on:click={logout} on:keypress={logout}>
+					<button class="btn p-0 text-2xl" on:click={doLogout} on:keypress={doLogout}>
 						<iconify-icon icon="material-symbols:logout" />
 					</button>
 				</section>

--- a/src/routes/oauth2/callback/+page.svelte
+++ b/src/routes/oauth2/callback/+page.svelte
@@ -82,7 +82,7 @@
 			return;
 		}
 
-		await setCredentials(result.access_token, jwt.payload.email);
+		await setCredentials(result.access_token, JSON.stringify(jwt.payload));
 
 		window.location = window.sessionStorage.getItem('oauth2_location') || '/';
 	}


### PR DESCRIPTION
We can cache the id_token until we are told to fully log out.  Now when an authorization_token expires, and is unset, we can trigger the OIDC authorization flow with the extsing email hint and, pow, automatic relog, in lieu of supporting reflresh_token.