### PR TITLE
Add PAT Provisioning

### DIFF
--- a/src/lib/credentials/index.ts
+++ b/src/lib/credentials/index.ts
@@ -7,6 +7,10 @@ export const token = sessionstore('token');
 // idToken is the user's idToken and contains OIDC information about them.
 export const profile = sessionstore('id_token');
 
+// pat is used to communicate a PAT from the oauth2 callback to the
+// client page.
+export const pat = sessionstore('pat');
+
 // This is called when the initial access token is acquired from the oauth
 // exchange.  It uses the token to rescope to a project, that's either selected
 // from persistent storage, and as a fallback, just selects the first one the
@@ -29,4 +33,13 @@ export function removeCredentials() {
 export function logout() {
 	profile.set(undefined);
 	token.set(undefined);
+}
+
+export function setPAT(patString: string) {
+	console.log(patString);
+	pat.set(patString);
+}
+
+export function unsetPAT() {
+	pat.set(undefined);
 }

--- a/src/lib/login/index.ts
+++ b/src/lib/login/index.ts
@@ -6,7 +6,22 @@ import { token, profile } from '$lib/credentials';
 import Base64url from 'crypto-js/enc-base64url';
 import SHA256 from 'crypto-js/sha256';
 
+export enum LoginType {
+	// Normal login flow will set the credentials in the browser.
+	Normal = 'normal',
+	// PAT flow will return the credentials as a POST.
+	PAT = 'pat'
+}
+
+export interface Oauth2State {
+	type: LoginType;
+}
+
 export function login() {
+	loginWithType(LoginType.Normal);
+}
+
+export function loginWithType(loginType: LoginType) {
 	let claims: { email: string } | undefined;
 
 	// Get the ID token first, as we can use it, if it exists to aid login below...
@@ -21,7 +36,7 @@ export function login() {
 
 	token.subscribe(async (token) => {
 		/* When a token isn't set, and its on the browser, do authentication */
-		if (token || !browser) {
+		if (!browser || (loginType == LoginType.Normal && token)) {
 			return;
 		}
 
@@ -46,6 +61,10 @@ export function login() {
 		window.sessionStorage.setItem('oauth2_code_challenge_verifier', codeChallengeVerifier);
 		window.sessionStorage.setItem('oauth2_location', window.location.pathname);
 
+		const state: Oauth2State = {
+			type: loginType
+		};
+
 		// TODO: set a nonce
 		const query = new URLSearchParams({
 			response_type: 'code',
@@ -54,7 +73,8 @@ export function login() {
 			code_challenge_method: 'S256',
 			code_challenge: codeChallenge,
 			scope: 'openid email profile',
-			nonce: nonceHash
+			nonce: nonceHash,
+			state: JSON.stringify(state)
 		});
 
 		// Set the login hint if we can as that avoids the login prompt.

--- a/src/lib/shell/ShellAppBar.svelte
+++ b/src/lib/shell/ShellAppBar.svelte
@@ -37,8 +37,6 @@
 
 		initials = givenName[0] + familyName[0];
 		picture = claims.picture;
-
-		console.log(initials);
 	});
 
 	let organizations: Models.Organizations;

--- a/src/lib/shell/ShellSideBar.svelte
+++ b/src/lib/shell/ShellSideBar.svelte
@@ -13,7 +13,8 @@
 				items: [
 					{ label: 'Organizations', href: '/identity/organizations' },
 					{ label: 'Groups', href: '/identity/groups' },
-					{ label: 'Projects', href: '/identity/projects' }
+					{ label: 'Projects', href: '/identity/projects' },
+					{ label: 'Tokens', href: '/identity/tokens' }
 				]
 			}
 		],

--- a/src/routes/(shell)/identity/tokens/+page.svelte
+++ b/src/routes/(shell)/identity/tokens/+page.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import type { ShellPageSettings } from '$lib/layouts/types.ts';
+	import ShellPage from '$lib/layouts/ShellPage.svelte';
+
+	const settings: ShellPageSettings = {
+		feature: 'Identity',
+		name: 'Tokens',
+		description: 'Issue access tokens for command line and automation tools.'
+	};
+
+	import * as Login from '$lib/login';
+
+	// create starts a new oauth2 flow to get a new access and refresh token.
+	function create() {
+		Login.loginWithType(Login.LoginType.PAT);
+	}
+
+	import { pat, unsetPAT } from '$lib/credentials';
+
+	let patJSON: string;
+
+	// If there is a PAT in storage, only show it the one time, and remore it
+	// immediately.
+	pat.subscribe((x: string) => {
+		console.log(pat);
+		console.log(x);
+		if (x) {
+			patJSON = x;
+			unsetPAT();
+		}
+	});
+
+	$: console.log(patJSON);
+</script>
+
+<ShellPage {settings}>
+	<button
+		class="btn variant-ghost-primary flex gap-2 items-center"
+		on:click={create}
+		on:keypress={create}
+	>
+		<iconify-icon icon="material-symbols:add" />
+		<span>Create</span>
+	</button>
+
+	{#if patJSON}
+		<h3 class="h3">Your Personal Access Token</h3>
+		<p>
+			<em>This token will only be shown once, so make a copy and keep it secure.</em>
+		</p>
+		<code>
+			{patJSON}
+		</code>
+	{/if}
+</ShellPage>


### PR DESCRIPTION
Okay so on reflection having an API for PATs is just wrong as you'd eventually have to share a refresh token, which being single use would log you out as soon as tooling refreshed, or vice versa, or the token was revoked.  So it's common sense that you do the oauth2 flow again in order to start a new ancestry of tokens.  Luckily we can just reuse what's already there and use the client state to control how the resulting token is handled.