### PR TITLE
Make all Resource Views use Shared Header

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: v0.2.9
-appVersion: v0.2.9
+version: v0.2.10
+appVersion: v0.2.10
 
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 

--- a/src/lib/formatters/index.ts
+++ b/src/lib/formatters/index.ts
@@ -46,3 +46,27 @@ export function timeOfDayFormatter(x: Hour) {
 
 	return `${x}:00 UTC`;
 }
+
+export function ageFormatter(time: Date): string {
+	// Get age of the instance in seconds.
+	const now = Date.now();
+
+	let age = Math.round((now - time.valueOf()) / 1000);
+
+	const seconds = age % 60;
+	age = Math.round(age / 60);
+
+	if (!age) return `${seconds}s`;
+
+	const minutes = age % 60;
+	age = Math.round(age / 60);
+
+	if (!age) return `${minutes}m ${seconds}s`;
+
+	const hours = age % 24;
+	age = Math.round(age / 24);
+
+	if (!age) return `${hours}h ${minutes}m ${seconds}s`;
+
+	return `${age}d ${hours}h ${minutes}m ${seconds}s`;
+}

--- a/src/lib/layouts/ShellListItem.svelte
+++ b/src/lib/layouts/ShellListItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as Kubernetes from '$lib/openapi/kubernetes';
 	import * as Identity from '$lib/openapi/identity';
+	import * as Formatters from '$lib/formatters';
 	import StatusIcon from '$lib/StatusIcon.svelte';
 
 	export let metadata: Kubernetes.ResourceReadMetadata;
@@ -24,30 +25,6 @@
 		const projectMeta = metadata as Kubernetes.ProjectScopedResourceReadMetadata;
 		scope = lookupProject(projectMeta.projectId);
 	}
-
-	function age(metadata: Kubernetes.ResourceReadMetadata): string {
-		// Get age of the instance in seconds.
-		const now = Date.now();
-
-		let age = Math.round((now - metadata.creationTime.valueOf()) / 1000);
-
-		const seconds = age % 60;
-		age = Math.round(age / 60);
-
-		if (!age) return `${seconds}s`;
-
-		const minutes = age % 60;
-		age = Math.round(age / 60);
-
-		if (!age) return `${minutes}m ${seconds}s`;
-
-		const hours = age % 24;
-		age = Math.round(age / 24);
-
-		if (!age) return `${hours}h ${minutes}m ${seconds}s`;
-
-		return `${age}d ${hours}h ${minutes}m ${seconds}s`;
-	}
 </script>
 
 <div class="flex flex-col lg:flex-row gap-4 items-top justify-between variant-glass rounded-lg p-4">
@@ -65,15 +42,15 @@
 			{:else}
 				<a class="font-bold" {href}>{metadata.name}</a>
 			{/if}
+			{#if metadata.description}
+				<div class="text-sm italic">{metadata.description}</div>
+			{/if}
 		</div>
-		{#if metadata.description}
-			<em>{metadata.description}</em>
-		{/if}
 
 		<div class="flex flex-col gap-2 text-sm">
 			<div class="flex gap-2 items-center text-sm">
 				<iconify-icon icon="mdi:clock-time-five-outline"></iconify-icon>
-				{age(metadata)}
+				{Formatters.ageFormatter(metadata.creationTime)}
 			</div>
 
 			{#if metadata.createdBy}

--- a/src/lib/layouts/ShellPage.svelte
+++ b/src/lib/layouts/ShellPage.svelte
@@ -13,6 +13,5 @@
 
 	<main class="flex flex-col gap-8">
 		<slot />
-		<main />
 	</main>
 </div>

--- a/src/lib/layouts/ShellViewHeader.svelte
+++ b/src/lib/layouts/ShellViewHeader.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import * as Kubernetes from '$lib/openapi/kubernetes';
+	import * as Formatters from '$lib/formatters';
+	import StatusIcon from '$lib/StatusIcon.svelte';
+	import ShellSection from '$lib/layouts/ShellSection.svelte';
+
+	export let metadata: Kubernetes.ResourceReadMetadata;
+</script>
+
+<div class="flex flex-col gap-4">
+	<div class="flex gap-4 items-center">
+		<StatusIcon {metadata} />
+		<div class="badge variant-soft">
+			{metadata.provisioningStatus}
+		</div>
+	</div>
+
+	<h2 class="h2">{metadata.name}</h2>
+
+	<div class="flex flex-col gap-2 text-sm">
+		<div class="flex gap-2 items-center text-sm">
+			<iconify-icon icon="mdi:clock-time-five-outline"></iconify-icon>
+			{Formatters.ageFormatter(metadata.creationTime)}
+		</div>
+
+		{#if metadata.createdBy}
+			<div class="flex gap-2 items-center">
+				<iconify-icon icon="mdi:user-outline"></iconify-icon>
+				{metadata.createdBy}
+			</div>
+		{/if}
+	</div>
+</div>
+
+<ShellSection title="Resource Metadata">
+	<label for="name">Display name.</label>
+	<input id="name" class="input" type="text" bind:value={metadata.name} />
+
+	<label for="name">Optional description.</label>
+	<input id="description" class="input" type="text" bind:value={metadata.description} />
+</ShellSection>

--- a/src/routes/(shell)/identity/groups/view/[id]/+page.svelte
+++ b/src/routes/(shell)/identity/groups/view/[id]/+page.svelte
@@ -3,6 +3,7 @@
 
 	import type { ShellPageSettings } from '$lib/layouts/types.ts';
 	import ShellPage from '$lib/layouts/ShellPage.svelte';
+	import ShellViewHeader from '$lib/layouts/ShellViewHeader.svelte';
 	import ShellSection from '$lib/layouts/ShellSection.svelte';
 
 	const settings: ShellPageSettings = {
@@ -85,7 +86,7 @@
 
 <ShellPage {settings}>
 	{#if group}
-		<h2 class="h2">{group.metadata.name}</h2>
+		<ShellViewHeader metadata={group.metadata} />
 
 		<ShellSection title="Roles">
 			<label class="label">

--- a/src/routes/(shell)/identity/organizations/view/[id]/+page.svelte
+++ b/src/routes/(shell)/identity/organizations/view/[id]/+page.svelte
@@ -4,6 +4,7 @@
 	import type { ShellPageSettings } from '$lib/layouts/types.ts';
 
 	import ShellPage from '$lib/layouts/ShellPage.svelte';
+	import ShellViewHeader from '$lib/layouts/ShellViewHeader.svelte';
 	import ShellSection from '$lib/layouts/ShellSection.svelte';
 
 	const settings: ShellPageSettings = {
@@ -87,7 +88,7 @@
 
 <ShellPage {settings}>
 	{#if organization}
-		<h2 class="h2">{organization.metadata.name}</h2>
+		<ShellViewHeader metadata={organization.metadata} />
 
 		<ShellSection title="Authentication Type">
 			<label for="organization-type"

--- a/src/routes/(shell)/identity/projects/view/[id]/+page.svelte
+++ b/src/routes/(shell)/identity/projects/view/[id]/+page.svelte
@@ -3,6 +3,7 @@
 
 	import type { ShellPageSettings } from '$lib/layouts/types.ts';
 	import ShellPage from '$lib/layouts/ShellPage.svelte';
+	import ShellViewHeader from '$lib/layouts/ShellViewHeader.svelte';
 	import ShellSection from '$lib/layouts/ShellSection.svelte';
 
 	const settings: ShellPageSettings = {
@@ -71,7 +72,7 @@
 
 <ShellPage {settings}>
 	{#if project}
-		<h2 class="h2">{project.metadata.name}</h2>
+		<ShellViewHeader metadata={project.metadata} />
 
 		<ShellSection title="Groups">
 			<label for="groups">


### PR DESCRIPTION
This lets us do fun things like rendering metadata on the view, and binding to it in a nice generica way and we instantly can update names and descriptions.