### PR TITLE
Unify Metadata Handling

### DIFF
--- a/src/lib/layouts/ShellMetadataSection.svelte
+++ b/src/lib/layouts/ShellMetadataSection.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import * as Validation from '$lib/validation';
+	import * as Kubernetes from '$lib/openapi/kubernetes';
+	import ShellSection from '$lib/layouts/ShellSection.svelte';
+
+	// Metadata object to bind to.
+	export let metadata: Kubernetes.ResourceMetadata;
+
+	// A list of names that already exist in this context for validation,
+	// so ensure you prune out the current one when using in an update
+	// dialog.
+	export let names: Array<string>;
+
+	// Whether the input is valid.
+	export let valid = false;
+
+	$: valid =
+		Validation.kubernetesNameValid(metadata.name) && Validation.unique(metadata.name, names);
+</script>
+
+<ShellSection title="Resource Metadata">
+	<label for="name"
+		>Display name. The name must be unique, contain no more than 63 characters, and contain only
+		letters, numbers and hyphens.</label
+	>
+	<input id="name" class="input" type="text" bind:value={metadata.name} />
+
+	<label for="name">Optional description.</label>
+	<input id="description" class="input" type="text" bind:value={metadata.description} />
+</ShellSection>

--- a/src/lib/layouts/ShellViewHeader.svelte
+++ b/src/lib/layouts/ShellViewHeader.svelte
@@ -2,7 +2,6 @@
 	import * as Kubernetes from '$lib/openapi/kubernetes';
 	import * as Formatters from '$lib/formatters';
 	import StatusIcon from '$lib/StatusIcon.svelte';
-	import ShellSection from '$lib/layouts/ShellSection.svelte';
 
 	export let metadata: Kubernetes.ResourceReadMetadata;
 </script>
@@ -31,11 +30,3 @@
 		{/if}
 	</div>
 </div>
-
-<ShellSection title="Resource Metadata">
-	<label for="name">Display name.</label>
-	<input id="name" class="input" type="text" bind:value={metadata.name} />
-
-	<label for="name">Optional description.</label>
-	<input id="description" class="input" type="text" bind:value={metadata.description} />
-</ShellSection>

--- a/src/lib/validation/index.ts
+++ b/src/lib/validation/index.ts
@@ -29,7 +29,7 @@ export function namedResourceNames(
 	});
 }
 
-export function unique(needle: string, haystack: Array<string>): boolean {
-	if (haystack == null) return true;
+export function unique(needle: string, haystack: Array<string> | undefined): boolean {
+	if (!haystack) return true;
 	return !haystack.includes(needle);
 }

--- a/src/routes/(shell)/identity/oauth2providers/+page.svelte
+++ b/src/routes/(shell)/identity/oauth2providers/+page.svelte
@@ -92,10 +92,7 @@
 
 	<ShellList>
 		{#each resources || [] as resource}
-			<ShellListItem
-				metadata={resource.metadata}
-				href="/identity/oauth2providers/view/{resource.metadata.id}"
-			>
+			<ShellListItem metadata={resource.metadata} href="#">
 				<button on:click={() => remove(resource)} on:keypress={() => remove(resource)}>
 					<iconify-icon icon="mdi:close" />
 				</button>

--- a/src/routes/(shell)/identity/organizations/view/[id]/+page.svelte
+++ b/src/routes/(shell)/identity/organizations/view/[id]/+page.svelte
@@ -5,6 +5,7 @@
 
 	import ShellPage from '$lib/layouts/ShellPage.svelte';
 	import ShellViewHeader from '$lib/layouts/ShellViewHeader.svelte';
+	import ShellMetadataSection from '$lib/layouts/ShellMetadataSection.svelte';
 	import ShellSection from '$lib/layouts/ShellSection.svelte';
 
 	const settings: ShellPageSettings = {
@@ -89,6 +90,7 @@
 <ShellPage {settings}>
 	{#if organization}
 		<ShellViewHeader metadata={organization.metadata} />
+		<ShellMetadataSection metadata={organization.metadata} names={[]} />
 
 		<ShellSection title="Authentication Type">
 			<label for="organization-type"


### PR DESCRIPTION
Make all create/updated views use the same metadata component that pacakges up all the validation into a single source of truth.  Plumb that into the rest of the code base.