### PR TITLE
Make Workload Pool View Driven By Model

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: v0.2.10
-appVersion: v0.2.10
+version: v0.2.11
+appVersion: v0.2.11
 
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 


### PR DESCRIPTION
Like the prior change, it makes code more compatible with creation and updates, and actually cleaner.