### PR TITLE
Add Region Display

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: v0.2.20
-appVersion: v0.2.20
+version: v0.2.21
+appVersion: v0.2.21
 
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 

--- a/src/lib/StatusIcon.svelte
+++ b/src/lib/StatusIcon.svelte
@@ -21,4 +21,4 @@
 	$: icon = getIcon(metadata);
 </script>
 
-<iconify-icon class="text-2xl {color}" {icon} />
+<iconify-icon class="text-lg {color}" {icon} />

--- a/src/lib/layouts/Badge.svelte
+++ b/src/lib/layouts/Badge.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	export let icon: string = '';
+</script>
+
+<div class="badge variant-soft flex gap-2 self-start">
+	{#if icon !== ''}
+		<iconify-icon class="text-lg" {icon} />
+	{/if}
+
+	<slot />
+</div>

--- a/src/lib/layouts/ShellListItem.svelte
+++ b/src/lib/layouts/ShellListItem.svelte
@@ -4,6 +4,7 @@
 	import * as Formatters from '$lib/formatters';
 	import StatusIcon from '$lib/StatusIcon.svelte';
 	import ShellMetadataItem from '$lib/layouts/ShellMetadataItem.svelte';
+	import Badge from '$lib/layouts/Badge.svelte';
 
 	export let metadata: Kubernetes.ResourceReadMetadata;
 	export let projects: Array<Identity.ProjectRead> = [];
@@ -32,11 +33,13 @@
 	class="flex flex-col lg:flex-row gap-4 items-top justify-between variant-glass border border-surface-300-600-token rounded-lg p-4"
 >
 	<div class="flex flex-col gap-4">
-		<div class="flex gap-4 items-center">
-			<StatusIcon {metadata} />
-			<div class="badge variant-soft">
+		<div class="flex gap-2 items-center">
+			<Badge>
+				<StatusIcon {metadata} />
 				{metadata.provisioningStatus}
-			</div>
+			</Badge>
+
+			<slot name="badges" />
 		</div>
 
 		<div class="flex gap-4 items-center">

--- a/src/lib/layouts/ShellMetadataItem.svelte
+++ b/src/lib/layouts/ShellMetadataItem.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <div class="flex gap-2 items-center">
-	<iconify-icon {icon} />
+	<iconify-icon class="text-lg" {icon} />
 
 	<slot />
 </div>

--- a/src/lib/layouts/ShellViewHeader.svelte
+++ b/src/lib/layouts/ShellViewHeader.svelte
@@ -2,16 +2,19 @@
 	import * as Kubernetes from '$lib/openapi/kubernetes';
 	import * as Formatters from '$lib/formatters';
 	import StatusIcon from '$lib/StatusIcon.svelte';
+	import Badge from '$lib/layouts/Badge.svelte';
 
 	export let metadata: Kubernetes.ResourceReadMetadata;
 </script>
 
 <div class="flex flex-col gap-4">
-	<div class="flex gap-4 items-center">
-		<StatusIcon {metadata} />
-		<div class="badge variant-soft">
+	<div class="flex gap-2 items-center">
+		<Badge>
+			<StatusIcon {metadata} />
 			{metadata.provisioningStatus}
-		</div>
+		</Badge>
+
+		<slot name="badges" />
 	</div>
 
 	<h2 class="h2">{metadata.name}</h2>

--- a/src/lib/openapi/region/.openapi-generator/FILES
+++ b/src/lib/openapi/region/.openapi-generator/FILES
@@ -21,7 +21,6 @@ models/PhysicalNetworkSpec.ts
 models/PhysicalNetworkWrite.ts
 models/ProjectScopedResourceReadMetadata.ts
 models/RegionRead.ts
-models/RegionScopedResourceMetadata.ts
 models/RegionSpec.ts
 models/RegionType.ts
 models/ResourceMetadata.ts

--- a/src/lib/openapi/region/apis/DefaultApi.ts
+++ b/src/lib/openapi/region/apis/DefaultApi.ts
@@ -50,41 +50,35 @@ export interface ApiV1OrganizationsOrganizationIDIdentitiesGetRequest {
     organizationID: string;
 }
 
-export interface ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsGetRequest {
+export interface ApiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesIdentityIDPhysicalNetworksPostRequest {
     organizationID: string;
     projectID: string;
-}
-
-export interface ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDExternalnetworksGetRequest {
-    organizationID: string;
-    projectID: string;
-    regionID: string;
-}
-
-export interface ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDFlavorsGetRequest {
-    organizationID: string;
-    projectID: string;
-    regionID: string;
-}
-
-export interface ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesIdentityIDPhysicalNetworksPostRequest {
-    organizationID: string;
-    projectID: string;
-    regionID: string;
     identityID: string;
     physicalNetworkWrite?: PhysicalNetworkWrite;
 }
 
-export interface ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesPostRequest {
+export interface ApiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesPostRequest {
     organizationID: string;
     projectID: string;
-    regionID: string;
     identityWrite: IdentityWrite;
 }
 
-export interface ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDImagesGetRequest {
+export interface ApiV1OrganizationsOrganizationIDRegionsGetRequest {
     organizationID: string;
-    projectID: string;
+}
+
+export interface ApiV1OrganizationsOrganizationIDRegionsRegionIDExternalnetworksGetRequest {
+    organizationID: string;
+    regionID: string;
+}
+
+export interface ApiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGetRequest {
+    organizationID: string;
+    regionID: string;
+}
+
+export interface ApiV1OrganizationsOrganizationIDRegionsRegionIDImagesGetRequest {
+    organizationID: string;
     regionID: string;
 }
 
@@ -129,148 +123,19 @@ export class DefaultApi extends runtime.BaseAPI {
     }
 
     /**
-     * List all regions.
-     */
-    async apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsGetRaw(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<RegionRead>>> {
-        if (requestParameters.organizationID === null || requestParameters.organizationID === undefined) {
-            throw new runtime.RequiredError('organizationID','Required parameter requestParameters.organizationID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsGet.');
-        }
-
-        if (requestParameters.projectID === null || requestParameters.projectID === undefined) {
-            throw new runtime.RequiredError('projectID','Required parameter requestParameters.projectID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsGet.');
-        }
-
-        const queryParameters: any = {};
-
-        const headerParameters: runtime.HTTPHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
-            // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("oauth2Authentication", []);
-        }
-
-        const response = await this.request({
-            path: `/api/v1/organizations/{organizationID}/projects/{projectID}/regions`.replace(`{${"organizationID"}}`, encodeURIComponent(String(requestParameters.organizationID))).replace(`{${"projectID"}}`, encodeURIComponent(String(requestParameters.projectID))),
-            method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
-        }, initOverrides);
-
-        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(RegionReadFromJSON));
-    }
-
-    /**
-     * List all regions.
-     */
-    async apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsGet(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<RegionRead>> {
-        const response = await this.apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsGetRaw(requestParameters, initOverrides);
-        return await response.value();
-    }
-
-    /**
-     * Get a list of external networks.
-     */
-    async apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDExternalnetworksGetRaw(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDExternalnetworksGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<ExternalNetwork>>> {
-        if (requestParameters.organizationID === null || requestParameters.organizationID === undefined) {
-            throw new runtime.RequiredError('organizationID','Required parameter requestParameters.organizationID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDExternalnetworksGet.');
-        }
-
-        if (requestParameters.projectID === null || requestParameters.projectID === undefined) {
-            throw new runtime.RequiredError('projectID','Required parameter requestParameters.projectID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDExternalnetworksGet.');
-        }
-
-        if (requestParameters.regionID === null || requestParameters.regionID === undefined) {
-            throw new runtime.RequiredError('regionID','Required parameter requestParameters.regionID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDExternalnetworksGet.');
-        }
-
-        const queryParameters: any = {};
-
-        const headerParameters: runtime.HTTPHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
-            // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("oauth2Authentication", []);
-        }
-
-        const response = await this.request({
-            path: `/api/v1/organizations/{organizationID}/projects/{projectID}/regions/{regionID}/externalnetworks`.replace(`{${"organizationID"}}`, encodeURIComponent(String(requestParameters.organizationID))).replace(`{${"projectID"}}`, encodeURIComponent(String(requestParameters.projectID))).replace(`{${"regionID"}}`, encodeURIComponent(String(requestParameters.regionID))),
-            method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
-        }, initOverrides);
-
-        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(ExternalNetworkFromJSON));
-    }
-
-    /**
-     * Get a list of external networks.
-     */
-    async apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDExternalnetworksGet(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDExternalnetworksGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<ExternalNetwork>> {
-        const response = await this.apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDExternalnetworksGetRaw(requestParameters, initOverrides);
-        return await response.value();
-    }
-
-    /**
-     * Lists all compute flavors that the authenticated user has access to
-     */
-    async apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDFlavorsGetRaw(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDFlavorsGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Flavor>>> {
-        if (requestParameters.organizationID === null || requestParameters.organizationID === undefined) {
-            throw new runtime.RequiredError('organizationID','Required parameter requestParameters.organizationID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDFlavorsGet.');
-        }
-
-        if (requestParameters.projectID === null || requestParameters.projectID === undefined) {
-            throw new runtime.RequiredError('projectID','Required parameter requestParameters.projectID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDFlavorsGet.');
-        }
-
-        if (requestParameters.regionID === null || requestParameters.regionID === undefined) {
-            throw new runtime.RequiredError('regionID','Required parameter requestParameters.regionID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDFlavorsGet.');
-        }
-
-        const queryParameters: any = {};
-
-        const headerParameters: runtime.HTTPHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
-            // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("oauth2Authentication", []);
-        }
-
-        const response = await this.request({
-            path: `/api/v1/organizations/{organizationID}/projects/{projectID}/regions/{regionID}/flavors`.replace(`{${"organizationID"}}`, encodeURIComponent(String(requestParameters.organizationID))).replace(`{${"projectID"}}`, encodeURIComponent(String(requestParameters.projectID))).replace(`{${"regionID"}}`, encodeURIComponent(String(requestParameters.regionID))),
-            method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
-        }, initOverrides);
-
-        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(FlavorFromJSON));
-    }
-
-    /**
-     * Lists all compute flavors that the authenticated user has access to
-     */
-    async apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDFlavorsGet(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDFlavorsGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Flavor>> {
-        const response = await this.apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDFlavorsGetRaw(requestParameters, initOverrides);
-        return await response.value();
-    }
-
-    /**
      * Create a new provider network.
      */
-    async apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesIdentityIDPhysicalNetworksPostRaw(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesIdentityIDPhysicalNetworksPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<PhysicalNetworkRead>> {
+    async apiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesIdentityIDPhysicalNetworksPostRaw(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesIdentityIDPhysicalNetworksPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<PhysicalNetworkRead>> {
         if (requestParameters.organizationID === null || requestParameters.organizationID === undefined) {
-            throw new runtime.RequiredError('organizationID','Required parameter requestParameters.organizationID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesIdentityIDPhysicalNetworksPost.');
+            throw new runtime.RequiredError('organizationID','Required parameter requestParameters.organizationID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesIdentityIDPhysicalNetworksPost.');
         }
 
         if (requestParameters.projectID === null || requestParameters.projectID === undefined) {
-            throw new runtime.RequiredError('projectID','Required parameter requestParameters.projectID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesIdentityIDPhysicalNetworksPost.');
-        }
-
-        if (requestParameters.regionID === null || requestParameters.regionID === undefined) {
-            throw new runtime.RequiredError('regionID','Required parameter requestParameters.regionID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesIdentityIDPhysicalNetworksPost.');
+            throw new runtime.RequiredError('projectID','Required parameter requestParameters.projectID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesIdentityIDPhysicalNetworksPost.');
         }
 
         if (requestParameters.identityID === null || requestParameters.identityID === undefined) {
-            throw new runtime.RequiredError('identityID','Required parameter requestParameters.identityID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesIdentityIDPhysicalNetworksPost.');
+            throw new runtime.RequiredError('identityID','Required parameter requestParameters.identityID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesIdentityIDPhysicalNetworksPost.');
         }
 
         const queryParameters: any = {};
@@ -285,7 +150,7 @@ export class DefaultApi extends runtime.BaseAPI {
         }
 
         const response = await this.request({
-            path: `/api/v1/organizations/{organizationID}/projects/{projectID}/regions/{regionID}/identities/{identityID}/physicalNetworks`.replace(`{${"organizationID"}}`, encodeURIComponent(String(requestParameters.organizationID))).replace(`{${"projectID"}}`, encodeURIComponent(String(requestParameters.projectID))).replace(`{${"regionID"}}`, encodeURIComponent(String(requestParameters.regionID))).replace(`{${"identityID"}}`, encodeURIComponent(String(requestParameters.identityID))),
+            path: `/api/v1/organizations/{organizationID}/projects/{projectID}/identities/{identityID}/physicalNetworks`.replace(`{${"organizationID"}}`, encodeURIComponent(String(requestParameters.organizationID))).replace(`{${"projectID"}}`, encodeURIComponent(String(requestParameters.projectID))).replace(`{${"identityID"}}`, encodeURIComponent(String(requestParameters.identityID))),
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
@@ -298,29 +163,25 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Create a new provider network.
      */
-    async apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesIdentityIDPhysicalNetworksPost(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesIdentityIDPhysicalNetworksPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<PhysicalNetworkRead> {
-        const response = await this.apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesIdentityIDPhysicalNetworksPostRaw(requestParameters, initOverrides);
+    async apiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesIdentityIDPhysicalNetworksPost(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesIdentityIDPhysicalNetworksPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<PhysicalNetworkRead> {
+        const response = await this.apiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesIdentityIDPhysicalNetworksPostRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
      * Create a new identity in the region.
      */
-    async apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesPostRaw(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<IdentityRead>> {
+    async apiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesPostRaw(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<IdentityRead>> {
         if (requestParameters.organizationID === null || requestParameters.organizationID === undefined) {
-            throw new runtime.RequiredError('organizationID','Required parameter requestParameters.organizationID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesPost.');
+            throw new runtime.RequiredError('organizationID','Required parameter requestParameters.organizationID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesPost.');
         }
 
         if (requestParameters.projectID === null || requestParameters.projectID === undefined) {
-            throw new runtime.RequiredError('projectID','Required parameter requestParameters.projectID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesPost.');
-        }
-
-        if (requestParameters.regionID === null || requestParameters.regionID === undefined) {
-            throw new runtime.RequiredError('regionID','Required parameter requestParameters.regionID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesPost.');
+            throw new runtime.RequiredError('projectID','Required parameter requestParameters.projectID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesPost.');
         }
 
         if (requestParameters.identityWrite === null || requestParameters.identityWrite === undefined) {
-            throw new runtime.RequiredError('identityWrite','Required parameter requestParameters.identityWrite was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesPost.');
+            throw new runtime.RequiredError('identityWrite','Required parameter requestParameters.identityWrite was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesPost.');
         }
 
         const queryParameters: any = {};
@@ -335,7 +196,7 @@ export class DefaultApi extends runtime.BaseAPI {
         }
 
         const response = await this.request({
-            path: `/api/v1/organizations/{organizationID}/projects/{projectID}/regions/{regionID}/identities`.replace(`{${"organizationID"}}`, encodeURIComponent(String(requestParameters.organizationID))).replace(`{${"projectID"}}`, encodeURIComponent(String(requestParameters.projectID))).replace(`{${"regionID"}}`, encodeURIComponent(String(requestParameters.regionID))),
+            path: `/api/v1/organizations/{organizationID}/projects/{projectID}/identities`.replace(`{${"organizationID"}}`, encodeURIComponent(String(requestParameters.organizationID))).replace(`{${"projectID"}}`, encodeURIComponent(String(requestParameters.projectID))),
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
@@ -348,25 +209,17 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Create a new identity in the region.
      */
-    async apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesPost(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<IdentityRead> {
-        const response = await this.apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDIdentitiesPostRaw(requestParameters, initOverrides);
+    async apiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesPost(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesPostRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<IdentityRead> {
+        const response = await this.apiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesPostRaw(requestParameters, initOverrides);
         return await response.value();
     }
 
     /**
-     * Lists all compute images that the authenticated user has access to.
+     * List all regions.
      */
-    async apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDImagesGetRaw(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDImagesGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Image>>> {
+    async apiV1OrganizationsOrganizationIDRegionsGetRaw(requestParameters: ApiV1OrganizationsOrganizationIDRegionsGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<RegionRead>>> {
         if (requestParameters.organizationID === null || requestParameters.organizationID === undefined) {
-            throw new runtime.RequiredError('organizationID','Required parameter requestParameters.organizationID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDImagesGet.');
-        }
-
-        if (requestParameters.projectID === null || requestParameters.projectID === undefined) {
-            throw new runtime.RequiredError('projectID','Required parameter requestParameters.projectID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDImagesGet.');
-        }
-
-        if (requestParameters.regionID === null || requestParameters.regionID === undefined) {
-            throw new runtime.RequiredError('regionID','Required parameter requestParameters.regionID was null or undefined when calling apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDImagesGet.');
+            throw new runtime.RequiredError('organizationID','Required parameter requestParameters.organizationID was null or undefined when calling apiV1OrganizationsOrganizationIDRegionsGet.');
         }
 
         const queryParameters: any = {};
@@ -379,7 +232,124 @@ export class DefaultApi extends runtime.BaseAPI {
         }
 
         const response = await this.request({
-            path: `/api/v1/organizations/{organizationID}/projects/{projectID}/regions/{regionID}/images`.replace(`{${"organizationID"}}`, encodeURIComponent(String(requestParameters.organizationID))).replace(`{${"projectID"}}`, encodeURIComponent(String(requestParameters.projectID))).replace(`{${"regionID"}}`, encodeURIComponent(String(requestParameters.regionID))),
+            path: `/api/v1/organizations/{organizationID}/regions`.replace(`{${"organizationID"}}`, encodeURIComponent(String(requestParameters.organizationID))),
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(RegionReadFromJSON));
+    }
+
+    /**
+     * List all regions.
+     */
+    async apiV1OrganizationsOrganizationIDRegionsGet(requestParameters: ApiV1OrganizationsOrganizationIDRegionsGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<RegionRead>> {
+        const response = await this.apiV1OrganizationsOrganizationIDRegionsGetRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * Get a list of external networks.
+     */
+    async apiV1OrganizationsOrganizationIDRegionsRegionIDExternalnetworksGetRaw(requestParameters: ApiV1OrganizationsOrganizationIDRegionsRegionIDExternalnetworksGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<ExternalNetwork>>> {
+        if (requestParameters.organizationID === null || requestParameters.organizationID === undefined) {
+            throw new runtime.RequiredError('organizationID','Required parameter requestParameters.organizationID was null or undefined when calling apiV1OrganizationsOrganizationIDRegionsRegionIDExternalnetworksGet.');
+        }
+
+        if (requestParameters.regionID === null || requestParameters.regionID === undefined) {
+            throw new runtime.RequiredError('regionID','Required parameter requestParameters.regionID was null or undefined when calling apiV1OrganizationsOrganizationIDRegionsRegionIDExternalnetworksGet.');
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.accessToken) {
+            // oauth required
+            headerParameters["Authorization"] = await this.configuration.accessToken("oauth2Authentication", []);
+        }
+
+        const response = await this.request({
+            path: `/api/v1/organizations/{organizationID}/regions/{regionID}/externalnetworks`.replace(`{${"organizationID"}}`, encodeURIComponent(String(requestParameters.organizationID))).replace(`{${"regionID"}}`, encodeURIComponent(String(requestParameters.regionID))),
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(ExternalNetworkFromJSON));
+    }
+
+    /**
+     * Get a list of external networks.
+     */
+    async apiV1OrganizationsOrganizationIDRegionsRegionIDExternalnetworksGet(requestParameters: ApiV1OrganizationsOrganizationIDRegionsRegionIDExternalnetworksGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<ExternalNetwork>> {
+        const response = await this.apiV1OrganizationsOrganizationIDRegionsRegionIDExternalnetworksGetRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * Lists all compute flavors that the authenticated user has access to
+     */
+    async apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGetRaw(requestParameters: ApiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Flavor>>> {
+        if (requestParameters.organizationID === null || requestParameters.organizationID === undefined) {
+            throw new runtime.RequiredError('organizationID','Required parameter requestParameters.organizationID was null or undefined when calling apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet.');
+        }
+
+        if (requestParameters.regionID === null || requestParameters.regionID === undefined) {
+            throw new runtime.RequiredError('regionID','Required parameter requestParameters.regionID was null or undefined when calling apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet.');
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.accessToken) {
+            // oauth required
+            headerParameters["Authorization"] = await this.configuration.accessToken("oauth2Authentication", []);
+        }
+
+        const response = await this.request({
+            path: `/api/v1/organizations/{organizationID}/regions/{regionID}/flavors`.replace(`{${"organizationID"}}`, encodeURIComponent(String(requestParameters.organizationID))).replace(`{${"regionID"}}`, encodeURIComponent(String(requestParameters.regionID))),
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(FlavorFromJSON));
+    }
+
+    /**
+     * Lists all compute flavors that the authenticated user has access to
+     */
+    async apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet(requestParameters: ApiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Flavor>> {
+        const response = await this.apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGetRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * Lists all compute images that the authenticated user has access to.
+     */
+    async apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGetRaw(requestParameters: ApiV1OrganizationsOrganizationIDRegionsRegionIDImagesGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Image>>> {
+        if (requestParameters.organizationID === null || requestParameters.organizationID === undefined) {
+            throw new runtime.RequiredError('organizationID','Required parameter requestParameters.organizationID was null or undefined when calling apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet.');
+        }
+
+        if (requestParameters.regionID === null || requestParameters.regionID === undefined) {
+            throw new runtime.RequiredError('regionID','Required parameter requestParameters.regionID was null or undefined when calling apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet.');
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        if (this.configuration && this.configuration.accessToken) {
+            // oauth required
+            headerParameters["Authorization"] = await this.configuration.accessToken("oauth2Authentication", []);
+        }
+
+        const response = await this.request({
+            path: `/api/v1/organizations/{organizationID}/regions/{regionID}/images`.replace(`{${"organizationID"}}`, encodeURIComponent(String(requestParameters.organizationID))).replace(`{${"regionID"}}`, encodeURIComponent(String(requestParameters.regionID))),
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
@@ -391,8 +361,8 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * Lists all compute images that the authenticated user has access to.
      */
-    async apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDImagesGet(requestParameters: ApiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDImagesGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Image>> {
-        const response = await this.apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDImagesGetRaw(requestParameters, initOverrides);
+    async apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet(requestParameters: ApiV1OrganizationsOrganizationIDRegionsRegionIDImagesGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Image>> {
+        const response = await this.apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGetRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/src/lib/openapi/region/models/IdentityRead.ts
+++ b/src/lib/openapi/region/models/IdentityRead.ts
@@ -19,12 +19,12 @@ import {
     IdentitySpecFromJSONTyped,
     IdentitySpecToJSON,
 } from './IdentitySpec';
-import type { RegionScopedResourceMetadata } from './RegionScopedResourceMetadata';
+import type { ProjectScopedResourceReadMetadata } from './ProjectScopedResourceReadMetadata';
 import {
-    RegionScopedResourceMetadataFromJSON,
-    RegionScopedResourceMetadataFromJSONTyped,
-    RegionScopedResourceMetadataToJSON,
-} from './RegionScopedResourceMetadata';
+    ProjectScopedResourceReadMetadataFromJSON,
+    ProjectScopedResourceReadMetadataFromJSONTyped,
+    ProjectScopedResourceReadMetadataToJSON,
+} from './ProjectScopedResourceReadMetadata';
 
 /**
  * A provider specific identity.
@@ -34,10 +34,10 @@ import {
 export interface IdentityRead {
     /**
      * 
-     * @type {RegionScopedResourceMetadata}
+     * @type {ProjectScopedResourceReadMetadata}
      * @memberof IdentityRead
      */
-    metadata: RegionScopedResourceMetadata;
+    metadata: ProjectScopedResourceReadMetadata;
     /**
      * 
      * @type {IdentitySpec}
@@ -67,7 +67,7 @@ export function IdentityReadFromJSONTyped(json: any, ignoreDiscriminator: boolea
     }
     return {
         
-        'metadata': RegionScopedResourceMetadataFromJSON(json['metadata']),
+        'metadata': ProjectScopedResourceReadMetadataFromJSON(json['metadata']),
         'spec': IdentitySpecFromJSON(json['spec']),
     };
 }
@@ -81,7 +81,7 @@ export function IdentityReadToJSON(value?: IdentityRead | null): any {
     }
     return {
         
-        'metadata': RegionScopedResourceMetadataToJSON(value.metadata),
+        'metadata': ProjectScopedResourceReadMetadataToJSON(value.metadata),
         'spec': IdentitySpecToJSON(value.spec),
     };
 }

--- a/src/lib/openapi/region/models/IdentitySpec.ts
+++ b/src/lib/openapi/region/models/IdentitySpec.ts
@@ -53,6 +53,12 @@ export interface IdentitySpec {
      */
     type: RegionType;
     /**
+     * The region an identity is provisioned in.
+     * @type {string}
+     * @memberof IdentitySpec
+     */
+    regionId: string;
+    /**
      * 
      * @type {IdentitySpecOpenStack}
      * @memberof IdentitySpec
@@ -66,6 +72,7 @@ export interface IdentitySpec {
 export function instanceOfIdentitySpec(value: object): boolean {
     let isInstance = true;
     isInstance = isInstance && "type" in value;
+    isInstance = isInstance && "regionId" in value;
 
     return isInstance;
 }
@@ -82,6 +89,7 @@ export function IdentitySpecFromJSONTyped(json: any, ignoreDiscriminator: boolea
         
         'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
         'type': RegionTypeFromJSON(json['type']),
+        'regionId': json['regionId'],
         'openstack': !exists(json, 'openstack') ? undefined : IdentitySpecOpenStackFromJSON(json['openstack']),
     };
 }
@@ -97,6 +105,7 @@ export function IdentitySpecToJSON(value?: IdentitySpec | null): any {
         
         'tags': value.tags === undefined ? undefined : ((value.tags as Array<any>).map(TagToJSON)),
         'type': RegionTypeToJSON(value.type),
+        'regionId': value.regionId,
         'openstack': IdentitySpecOpenStackToJSON(value.openstack),
     };
 }

--- a/src/lib/openapi/region/models/IdentityWriteSpec.ts
+++ b/src/lib/openapi/region/models/IdentityWriteSpec.ts
@@ -32,6 +32,12 @@ export interface IdentityWriteSpec {
      * @memberof IdentityWriteSpec
      */
     tags?: Array<Tag>;
+    /**
+     * The region an identity is provisioned in.
+     * @type {string}
+     * @memberof IdentityWriteSpec
+     */
+    regionId: string;
 }
 
 /**
@@ -39,6 +45,7 @@ export interface IdentityWriteSpec {
  */
 export function instanceOfIdentityWriteSpec(value: object): boolean {
     let isInstance = true;
+    isInstance = isInstance && "regionId" in value;
 
     return isInstance;
 }
@@ -54,6 +61,7 @@ export function IdentityWriteSpecFromJSONTyped(json: any, ignoreDiscriminator: b
     return {
         
         'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'regionId': json['regionId'],
     };
 }
 
@@ -67,6 +75,7 @@ export function IdentityWriteSpecToJSON(value?: IdentityWriteSpec | null): any {
     return {
         
         'tags': value.tags === undefined ? undefined : ((value.tags as Array<any>).map(TagToJSON)),
+        'regionId': value.regionId,
     };
 }
 

--- a/src/lib/openapi/region/models/index.ts
+++ b/src/lib/openapi/region/models/index.ts
@@ -20,7 +20,6 @@ export * from './PhysicalNetworkSpec';
 export * from './PhysicalNetworkWrite';
 export * from './ProjectScopedResourceReadMetadata';
 export * from './RegionRead';
-export * from './RegionScopedResourceMetadata';
 export * from './RegionSpec';
 export * from './RegionType';
 export * from './ResourceMetadata';

--- a/src/lib/regionutil/index.ts
+++ b/src/lib/regionutil/index.ts
@@ -1,0 +1,23 @@
+import * as Region from '$lib/openapi/region';
+
+export function name(regions: Array<Region.RegionRead>, regionID: string): string {
+	if (!regions || !regionID) {
+		return 'unknown';
+	}
+
+	const region = regions.find((x) => x.metadata.id == regionID);
+	if (!region) {
+		return 'unknown';
+	}
+
+	return region.metadata.name;
+}
+
+export function icon(regions: Array<Region.RegionRead>, regionID: string): string {
+	const regionName = name(regions, regionID);
+	if (regionName === 'unknown') {
+		return 'circle-flags:az';
+	}
+
+	return `circle-flags:${regionName.split('-')[0]}`;
+}

--- a/src/routes/(shell)/infrastructure/clusters/create/+page.svelte
+++ b/src/routes/(shell)/infrastructure/clusters/create/+page.svelte
@@ -96,18 +96,17 @@
 			.catch((e: Error) => Clients.error(e));
 	}
 
-	function updateRegions(at: InternalToken, organizationID: string, projectID: string) {
-		if (!at || !organizationID || !projectID) return;
+	function updateRegions(at: InternalToken, organizationID: string) {
+		if (!at || !organizationID) return;
 
 		const parameters = {
-			organizationID: organizationID,
-			projectID: projectID
+			organizationID: organizationID
 		};
 
 		/* Get top-level resources required for the first step */
 		/* TODO: parallelize with Promise.all */
 		Clients.region(toastStore, at)
-			.apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsGet(parameters)
+			.apiV1OrganizationsOrganizationIDRegionsGet(parameters)
 			.then((v: Array<Region.RegionRead>) => {
 				if (v.length == 0) return;
 
@@ -117,7 +116,7 @@
 			.catch((e: Error) => Clients.error(e));
 	}
 
-	$: updateRegions(at, organizationID, projectID);
+	$: updateRegions(at, organizationID);
 
 	function updateClusterManagers(at: InternalToken, projectID: string) {
 		if (!at || !projectID) return;
@@ -173,48 +172,36 @@
 	$: step2Valid = metadataValid;
 
 	/* Once the region has been selected we can poll the images and other resources */
-	function updateImages(
-		at: InternalToken,
-		organizationID: string,
-		projectID: string,
-		regionID: string
-	): void {
-		if (!at || !organizationID || !projectID || !regionID) return;
+	function updateImages(at: InternalToken, organizationID: string, regionID: string): void {
+		if (!at || !organizationID || !regionID) return;
 
 		const parameters = {
 			organizationID: organizationID,
-			projectID: projectID,
 			regionID: regionID
 		};
 
 		Clients.region(toastStore, at)
-			.apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDImagesGet(parameters)
+			.apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet(parameters)
 			.then((v: Array<Region.Image>) => (images = v))
 			.catch((e: Error) => Clients.error(e));
 	}
 
-	function updateFlavors(
-		at: InternalToken,
-		organizationID: string,
-		projectID: string,
-		regionID: string
-	): void {
-		if (!at || !organizationID || !projectID || !regionID) return;
+	function updateFlavors(at: InternalToken, organizationID: string, regionID: string): void {
+		if (!at || !organizationID || !regionID) return;
 
 		const parameters = {
 			organizationID: organizationID,
-			projectID: projectID,
 			regionID: regionID
 		};
 
 		Clients.region(toastStore, at)
-			.apiV1OrganizationsOrganizationIDProjectsProjectIDRegionsRegionIDFlavorsGet(parameters)
+			.apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet(parameters)
 			.then((v: Array<Region.Flavor>) => (flavors = v))
 			.catch((e: Error) => Clients.error(e));
 	}
 
-	$: updateImages(at, organizationID, projectID, regionID);
-	$: updateFlavors(at, organizationID, projectID, regionID);
+	$: updateImages(at, organizationID, regionID);
+	$: updateFlavors(at, organizationID, regionID);
 
 	$: resource.spec.regionId = regionID;
 


### PR DESCRIPTION
On reflection mapping region IDs to project scoped region names was way too complex, so we've moved to organization scoped regions.  We can still - under the hood - do any project filtering, but crucially only perform a single lookup for all identities/clusters.  As these two primitives have parity now, we can handle regions generically and add in a new item badge to convey which region something is living in.