### PR TITLE
Fix Refresh Token Handling

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: v0.2.22
-appVersion: v0.2.22
+version: v0.2.23
+appVersion: v0.2.23
 
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 


### PR DESCRIPTION
When a refresh token is used, we need to update the access token in session storage to account for the updated expiry time etc.  There is still a race whereby multiple API calls at once will do multiple refresh promises which we could sort out at some point.