### PR TITLE
Fix Project Scope Resolution

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: v0.2.23
-appVersion: v0.2.23
+version: v0.2.24
+appVersion: v0.2.24
 
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 

--- a/src/lib/layouts/ShellListItem.svelte
+++ b/src/lib/layouts/ShellListItem.svelte
@@ -23,10 +23,17 @@
 
 	let scope: string;
 
-	if ('projectId' in metadata) {
-		const projectMeta = metadata as Kubernetes.ProjectScopedResourceReadMetadata;
-		scope = lookupProject(projectMeta.projectId);
+	function updateScope(
+		metadata: Kubernetes.ResourceReadMetadata,
+		projects: Array<Identity.ProjectRead>
+	) {
+		if ('projectId' in metadata) {
+			const projectMeta = metadata as Kubernetes.ProjectScopedResourceReadMetadata;
+			scope = lookupProject(projectMeta.projectId);
+		}
 	}
+
+	$: updateScope(metadata, projects);
 </script>
 
 <div


### PR DESCRIPTION
There is a race where the project ID should be resolved before the project list is available, thus displaying the ID and not the name.  By making this more reactive we will update when the data is available.