### PR TITLE
Fix Baremetal Volumes

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: v0.2.33
-appVersion: v0.2.33
+version: v0.2.34
+appVersion: v0.2.34
 
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 

--- a/src/lib/WorkloadPoolCreate.svelte
+++ b/src/lib/WorkloadPoolCreate.svelte
@@ -47,7 +47,23 @@
 
 	let persistentStorage: boolean = Boolean(pool.machine.disk);
 
-	function updateDisk(enabled: boolean) {
+	function updateDisk(
+		enabled: boolean,
+		flavors: Array<Region.Flavor>,
+		flavorID: string | undefined
+	) {
+		if (!flavors || !flavorID) return;
+
+		/* Volumes cannot be used on baremetal nodes */
+		const allowed = !lookupFlavor(flavors, flavorID).spec.baremetal;
+		if (!allowed) {
+			if (pool.machine.disk) {
+				delete pool.machine.disk;
+			}
+
+			return;
+		}
+
 		if (enabled && !pool.machine.disk) {
 			pool.machine.disk = {
 				size: 50
@@ -57,7 +73,7 @@
 		}
 	}
 
-	$: updateDisk(persistentStorage);
+	$: updateDisk(persistentStorage, flavors, pool.machine.flavorId);
 
 	$: valid = Validation.kubernetesNameValid(pool.name);
 


### PR DESCRIPTION
We need to special case baremetal nodes as they are not allowed volumes at all and cause previsioning failure immediately.  Te previous code just hid the inputs, and didn't actually prune the dead request data.