### PR TITLE
Remove Clipboard

### DIFF
--- a/src/lib/forms/Clipboard.svelte
+++ b/src/lib/forms/Clipboard.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	interface Props {
+		id: string;
+		value: string;
+	}
+
+	let { id, value }: Props = $props();
+
+	function copyToClipboard() {
+		const input = document.getElementById(id) as HTMLInputElement;
+		if (!input) return;
+
+		navigator.clipboard.writeText(input.value);
+	}
+</script>
+
+<div class="input-group input-group-divider grid-cols-[1fr_auto]">
+	<input
+		{id}
+		{value}
+		type="text"
+		disabled
+		class="overflow-hidden text-ellipsis whitespace-nowrap"
+	/>
+	<button
+		class="variant-filled-primary flex items-center gap-2"
+		onclick={() => copyToClipboard()}
+		onkeypress={() => copyToClipboard()}
+	>
+		<iconify-icon icon="mdi:clipboard-outline"></iconify-icon>
+		<span>Copy</span>
+	</button>
+</div>

--- a/src/routes/(shell)/identity/oauth2providers/create/+page.svelte
+++ b/src/routes/(shell)/identity/oauth2providers/create/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { run } from 'svelte/legacy';
+	import { browser } from '$app/environment';
 
 	/* Page setup */
 	import type { ShellPageSettings } from '$lib/layouts/types.ts';
@@ -7,6 +8,7 @@
 	import ShellMetadataSection from '$lib/layouts/ShellMetadataSection.svelte';
 	import ShellSection from '$lib/layouts/ShellSection.svelte';
 	import TextInput from '$lib/forms/TextInput.svelte';
+	import Clipboard from '$lib/forms/Clipboard.svelte';
 	import * as Validation from '$lib/validation';
 
 	const settings: ShellPageSettings = {
@@ -90,9 +92,6 @@
 	var callback: string = browser
 		? window.location.protocol + '://' + window.location.hostname + '/oauth2/callback'
 		: '';
-
-	import { browser } from '$app/environment';
-	import { clipboard } from '@skeletonlabs/skeleton';
 </script>
 
 <ShellPage {settings}>
@@ -103,21 +102,7 @@
 			>Oauth2 callback address. This is used to configure your OIDC application with before
 			continuing with the following fields.</label
 		>
-		<div class="input-group input-group-divider grid-cols-[1fr_auto]">
-			<input
-				class="input overflow-hidden text-ellipsis whitespace-nowrap"
-				data-clipboard="callback"
-				value={callback}
-				disabled
-			/>
-			<button
-				class="variant-filled-primary"
-				use:clipboard={{ input: 'callback' }}
-				aria-label="copy to clipboard"
-			>
-				<iconify-icon icon="mdi:clipboard-outline"></iconify-icon>
-			</button>
-		</div>
+		<Clipboard id="callback" value={callback} />
 
 		<TextInput
 			id="issuer"

--- a/src/routes/(shell)/identity/serviceaccounts/create/+page.svelte
+++ b/src/routes/(shell)/identity/serviceaccounts/create/+page.svelte
@@ -9,7 +9,7 @@
 	import ShellSection from '$lib/layouts/ShellSection.svelte';
 	import MultiSelect from '$lib/forms/MultiSelect.svelte';
 	import Button from '$lib/forms/Button.svelte';
-	import { clipboard } from '@skeletonlabs/skeleton';
+	import Clipboard from '$lib/forms/Clipboard.svelte';
 
 	const settings: ShellPageSettings = {
 		feature: 'Identity',
@@ -105,21 +105,7 @@
 			<p>
 				<em>This token will only be shown once, so make a copy and keep it secure.</em>
 			</p>
-			<div class="flex gap-4 items-center">
-				<div
-					data-clipboard="pat"
-					class="p-2 overflow-hidden textarea text-ellipsis whitespace-nowrap"
-				>
-					{serviceAccount.status.accessToken}
-				</div>
-				<button
-					use:clipboard={{ element: 'pat' }}
-					class="btn variant-filled-primary flex items-center"
-				>
-					<iconify-icon icon="mdi:clipboard-outline"></iconify-icon>
-					<span>Copy</span>
-				</button>
-			</div>
+			<Clipboard id="access-token" value={serviceAccount.status.accessToken || ''} />
 		</ShellSection>
 
 		<div class="flex">

--- a/src/routes/(shell)/identity/serviceaccounts/view/[id]/+page.svelte
+++ b/src/routes/(shell)/identity/serviceaccounts/view/[id]/+page.svelte
@@ -10,7 +10,7 @@
 	import ShellSection from '$lib/layouts/ShellSection.svelte';
 	import MultiSelect from '$lib/forms/MultiSelect.svelte';
 	import Button from '$lib/forms/Button.svelte';
-	import { clipboard } from '@skeletonlabs/skeleton';
+	import Clipboard from '$lib/forms/Clipboard.svelte';
 
 	const settings: ShellPageSettings = {
 		feature: 'Identity',
@@ -135,21 +135,7 @@
 			<p>
 				<em>This token will only be shown once, so make a copy and keep it secure.</em>
 			</p>
-			<div class="flex gap-4 items-center">
-				<div
-					data-clipboard="pat"
-					class="p-2 overflow-hidden textarea text-ellipsis whitespace-nowrap"
-				>
-					{newServiceAccount.status.accessToken}
-				</div>
-				<button
-					use:clipboard={{ element: 'pat' }}
-					class="btn variant-filled-primary flex items-center"
-				>
-					<iconify-icon icon="mdi:clipboard-outline"></iconify-icon>
-					<span>Copy</span>
-				</button>
-			</div>
+			<Clipboard id="access-token" value={newServiceAccount.status.accessToken || ''} />
 		</ShellSection>
 
 		<div class="flex">


### PR DESCRIPTION
Removed in skeleton 3, plus there is a native API to use in the browser now.