### PR TITLE
Handle List Item Overflow Gracefully

### DIFF
--- a/src/lib/layouts/ShellList.svelte
+++ b/src/lib/layouts/ShellList.svelte
@@ -6,6 +6,8 @@
 	let { children }: Props = $props();
 </script>
 
-<div class="flex flex-col gap-4 lg:grid lg:grid-cols-[repeat(6,max-content),auto,max-content]">
+<div
+	class="flex flex-col gap-4 lg:grid lg:grid-cols-[repeat(6,minmax(0,max-content)),auto,max-content]"
+>
 	{@render children?.()}
 </div>

--- a/src/lib/layouts/ShellListItemHeader.svelte
+++ b/src/lib/layouts/ShellListItemHeader.svelte
@@ -30,7 +30,7 @@
 
 {#snippet header()}
 	<header class="flex flex-col gap-1">
-		<div class="h5 font-bold">
+		<div class="h5 font-bold overflow-hidden text-ellipsis whitespace-nowrap">
 			{#if title}
 				{title}
 			{:else if metadata}


### PR DESCRIPTION
Rather than letting it grow to infinity or having a wrap, hide the excess and and add ellipses.