### PR TITLE
Remove Sensitive Google Scopes

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: v0.3.3-rc1
-appVersion: v0.3.3-rc1
+version: v0.3.3-rc2
+appVersion: v0.3.3-rc2
 
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 

--- a/src/lib/openapi/identity/.openapi-generator/FILES
+++ b/src/lib/openapi/identity/.openapi-generator/FILES
@@ -6,7 +6,6 @@ models/AclEndpoint.ts
 models/AclOperation.ts
 models/AclScopedEndpoints.ts
 models/AuthMethod.ts
-models/AvailableGroup.ts
 models/Claim.ts
 models/CodeChallengeMethod.ts
 models/GrantType.ts

--- a/src/lib/openapi/identity/apis/DefaultApi.ts
+++ b/src/lib/openapi/identity/apis/DefaultApi.ts
@@ -16,7 +16,6 @@
 import * as runtime from '../runtime';
 import type {
   Acl,
-  AvailableGroup,
   GroupRead,
   GroupWrite,
   JsonWebKeySet,
@@ -41,8 +40,6 @@ import type {
 import {
     AclFromJSON,
     AclToJSON,
-    AvailableGroupFromJSON,
-    AvailableGroupToJSON,
     GroupReadFromJSON,
     GroupReadToJSON,
     GroupWriteFromJSON,
@@ -86,10 +83,6 @@ import {
 } from '../models/index';
 
 export interface ApiV1OrganizationsOrganizationIDAclGetRequest {
-    organizationID: string;
-}
-
-export interface ApiV1OrganizationsOrganizationIDAvailableGroupsGetRequest {
     organizationID: string;
 }
 
@@ -363,41 +356,6 @@ export class DefaultApi extends runtime.BaseAPI {
      */
     async apiV1OrganizationsOrganizationIDAclGet(requestParameters: ApiV1OrganizationsOrganizationIDAclGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Acl> {
         const response = await this.apiV1OrganizationsOrganizationIDAclGetRaw(requestParameters, initOverrides);
-        return await response.value();
-    }
-
-    /**
-     * Returns a list of groups that are defined for the organization in the domain provider.
-     */
-    async apiV1OrganizationsOrganizationIDAvailableGroupsGetRaw(requestParameters: ApiV1OrganizationsOrganizationIDAvailableGroupsGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<AvailableGroup>>> {
-        if (requestParameters.organizationID === null || requestParameters.organizationID === undefined) {
-            throw new runtime.RequiredError('organizationID','Required parameter requestParameters.organizationID was null or undefined when calling apiV1OrganizationsOrganizationIDAvailableGroupsGet.');
-        }
-
-        const queryParameters: any = {};
-
-        const headerParameters: runtime.HTTPHeaders = {};
-
-        if (this.configuration && this.configuration.accessToken) {
-            // oauth required
-            headerParameters["Authorization"] = await this.configuration.accessToken("oauth2Authentication", []);
-        }
-
-        const response = await this.request({
-            path: `/api/v1/organizations/{organizationID}/available-groups`.replace(`{${"organizationID"}}`, encodeURIComponent(String(requestParameters.organizationID))),
-            method: 'GET',
-            headers: headerParameters,
-            query: queryParameters,
-        }, initOverrides);
-
-        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(AvailableGroupFromJSON));
-    }
-
-    /**
-     * Returns a list of groups that are defined for the organization in the domain provider.
-     */
-    async apiV1OrganizationsOrganizationIDAvailableGroupsGet(requestParameters: ApiV1OrganizationsOrganizationIDAvailableGroupsGetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<AvailableGroup>> {
-        const response = await this.apiV1OrganizationsOrganizationIDAvailableGroupsGetRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/src/lib/openapi/identity/models/GroupSpec.ts
+++ b/src/lib/openapi/identity/models/GroupSpec.ts
@@ -31,12 +31,6 @@ export interface GroupSpec {
      * @memberof GroupSpec
      */
     roleIDs: Array<string>;
-    /**
-     * A list of provider groups.
-     * @type {Array<string>}
-     * @memberof GroupSpec
-     */
-    providerGroups?: Array<string>;
 }
 
 /**
@@ -61,7 +55,6 @@ export function GroupSpecFromJSONTyped(json: any, ignoreDiscriminator: boolean):
         
         'users': !exists(json, 'users') ? undefined : json['users'],
         'roleIDs': json['roleIDs'],
-        'providerGroups': !exists(json, 'providerGroups') ? undefined : json['providerGroups'],
     };
 }
 
@@ -76,7 +69,6 @@ export function GroupSpecToJSON(value?: GroupSpec | null): any {
         
         'users': value.users,
         'roleIDs': value.roleIDs,
-        'providerGroups': value.providerGroups,
     };
 }
 

--- a/src/lib/openapi/identity/models/index.ts
+++ b/src/lib/openapi/identity/models/index.ts
@@ -5,7 +5,6 @@ export * from './AclEndpoint';
 export * from './AclOperation';
 export * from './AclScopedEndpoints';
 export * from './AuthMethod';
-export * from './AvailableGroup';
 export * from './Claim';
 export * from './CodeChallengeMethod';
 export * from './GrantType';

--- a/src/routes/(shell)/identity/groups/create/+page.svelte
+++ b/src/routes/(shell)/identity/groups/create/+page.svelte
@@ -40,7 +40,6 @@
 
 	let groups: Array<Identity.GroupRead> | undefined = $state();
 	let availableRoles: Array<Identity.RoleRead> | undefined = $state();
-	let availableGroups: Array<Identity.AvailableGroup> | undefined = $state();
 
 	$effect.pre(() => {
 		const parameters = {
@@ -56,14 +55,6 @@
 			.apiV1OrganizationsOrganizationIDRolesGet(parameters)
 			.then((v: Array<Identity.RoleRead>) => (availableRoles = v))
 			.catch((e: Error) => Clients.error(e));
-
-		Clients.identity(toastStore, at)
-			.apiV1OrganizationsOrganizationIDAvailableGroupsGet(parameters)
-			.then((v: Array<Identity.AvailableGroup>) => {
-				if (v.length == 0) return;
-				availableGroups = v;
-			})
-			.catch((e: Error) => Clients.error(e));
 	});
 
 	let names = $derived((groups || []).map((x) => x.metadata.name));
@@ -74,8 +65,7 @@
 		},
 		spec: {
 			roleIDs: [],
-			users: [],
-			providerGroups: []
+			users: []
 		}
 	});
 
@@ -116,19 +106,6 @@
 	</ShellSection>
 
 	<ShellSection title="Users">
-		{#if availableGroups && resource.spec.providerGroups}
-			<MultiSelect
-				id="provider-groups"
-				label="Include users with identity provider groups."
-				hint="To add and remove members edit the group with your identity provider."
-				bind:value={resource.spec.providerGroups}
-			>
-				{#each availableGroups || [] as group}
-					<option value={group.name}>{group.displayName || group.name}</option>
-				{/each}
-			</MultiSelect>
-		{/if}
-
 		{#if resource.spec.users}
 			<InputChips
 				name="users"

--- a/src/routes/(shell)/identity/groups/view/[id]/+page.svelte
+++ b/src/routes/(shell)/identity/groups/view/[id]/+page.svelte
@@ -43,7 +43,6 @@
 	// Get root resources from the API.
 	let groups: Array<Identity.GroupRead> | undefined = $state();
 	let availableRoles: Array<Identity.RoleRead> | undefined = $state();
-	let availableGroups: Array<Identity.AvailableGroup> | undefined = $state();
 
 	$effect.pre(() => {
 		const parameters = {
@@ -59,13 +58,6 @@
 			.apiV1OrganizationsOrganizationIDRolesGet(parameters)
 			.then((v: Array<Identity.RoleRead>) => (availableRoles = v))
 			.catch((e: Error) => Clients.error(e));
-
-		Clients.identity(toastStore, at)
-			.apiV1OrganizationsOrganizationIDAvailableGroupsGet(parameters)
-			.then((v: Array<Identity.AvailableGroup>) => {
-				availableGroups = v;
-			})
-			.catch((e: Error) => Clients.error(e));
 	});
 
 	// Once we know the groups, select the one we are viewing.
@@ -76,7 +68,6 @@
 	// Add in any defaults before we rnder the DOM so we have things to bind to.
 	$effect.pre(() => {
 		if (!group) return;
-		if (!group.spec.providerGroups) group.spec.providerGroups = [];
 		if (!group.spec.users) group.spec.users = [];
 	});
 
@@ -125,19 +116,6 @@
 		</ShellSection>
 
 		<ShellSection title="Users">
-			{#if availableGroups && group.spec.providerGroups}
-				<MultiSelect
-					id="provider-groups"
-					label="Include users with identity provider groups."
-					hint="To add and remove members edit the group with your identity provider."
-					bind:value={group.spec.providerGroups}
-				>
-					{#each availableGroups || [] as group}
-						<option value={group.name}>{group.displayName || group.name}</option>
-					{/each}
-				</MultiSelect>
-			{/if}
-
 			{#if group.spec.users}
 				<InputChips
 					name="users"


### PR DESCRIPTION
With implicit groups, that requires a sensitive scope from Google, and they deem it necessary to make you record a video demoing your app so they can act as judge, jury and executioner as to whether or not it's allowed without a bunch of warnings.  Removing this removes that barrier.