### PR TITLE
Update Cluster Views

### DIFF
--- a/src/lib/forms/PopupButton.svelte
+++ b/src/lib/forms/PopupButton.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import { popup } from '@skeletonlabs/skeleton';
+
+	interface Props {
+		id: string;
+		icon: string;
+		label: string;
+		disabled?: boolean;
+		content: Snippet;
+		[key: string]: any;
+	}
+
+	let { id, icon, label, disabled = $bindable(), content, ...props }: Props = $props();
+</script>
+
+<button
+	use:popup={{ event: 'click', target: id, placement: 'bottom-end' }}
+	class="btn flex gap-2 items-center {props.class || ''}"
+	{disabled}
+>
+	<iconify-icon {icon}> </iconify-icon>
+	{label}
+</button>
+
+<div data-popup={id}>
+	<div class="card p-4 shadow-lg">
+		{@render content()}
+	</div>
+</div>

--- a/src/lib/layouts/GroupedList.svelte
+++ b/src/lib/layouts/GroupedList.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import ShellList from '$lib/layouts/ShellList.svelte';
+
+	interface Props {
+		groups: Record<string, Array<any>>;
+		header: Snippet<[string]>;
+		item: Snippet<[any]>;
+	}
+
+	let { groups, header, item }: Props = $props();
+</script>
+
+<div class="flex flex-col gap-4">
+	{#each Object.keys(groups) as key}
+		{@render header(key)}
+
+		{#if groups[key].length}
+			<ShellList>
+				{#each groups[key] as group}
+					{@render item(group)}
+				{/each}
+			</ShellList>
+		{:else}
+			There are no resources in this group, create one to get started.
+		{/if}
+	{/each}
+</div>

--- a/src/lib/layouts/ShellListItem.svelte
+++ b/src/lib/layouts/ShellListItem.svelte
@@ -24,7 +24,7 @@
 
 	{#if footer}
 		<div class="col-span-full">
-			<details open>
+			<details>
 				<summary class="list-none flex justify-center">
 					<div class="bg-surface-200-700-token rounded shadow h-1 w-16"></div>
 				</summary>

--- a/src/lib/regionutil/index.ts
+++ b/src/lib/regionutil/index.ts
@@ -13,6 +13,10 @@ export function name(regions: Array<Region.RegionRead> | undefined, regionID: st
 	return region.metadata.name;
 }
 
+export function iconIcon(region: Region.RegionRead): string {
+	return `circle-flags:${region.metadata.name.split('-')[0]}`;
+}
+
 export function icon(regions: Array<Region.RegionRead> | undefined, regionID: string): string {
 	const regionName = name(regions, regionID);
 	if (regionName === 'unknown') {

--- a/src/lib/shell/AppBar.svelte
+++ b/src/lib/shell/AppBar.svelte
@@ -56,7 +56,7 @@
 
 	{#snippet trail()}
 		<!-- User drop down -->
-		<button class="btn p-0" use:popup={{ event: 'click', target: 'user' }}>
+		<button class="btn p-0" use:popup={{ event: 'click', target: 'user', placement: 'bottom-end' }}>
 			<Avatar
 				src={picture}
 				{initials}


### PR DESCRIPTION
A couple of enhancements here, first we group resources by project, this then allows us to add a cluster directly into a project rather than having to select from a drop down. The second is that per-project creation also adds in a region dropdown dialog, so that's directly know during creation.  All of this means we can now move all of the dynamic lookup stuff from pages into universal load functions, and do project scoped RBAC rules.