### PR TITLE
Add an Error Page

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: v0.3.4-rc5
-appVersion: v0.3.4-rc5
+version: v0.3.4-rc6
+appVersion: v0.3.4-rc6
 
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 

--- a/src/lib/layouts/ErrorPage.svelte
+++ b/src/lib/layouts/ErrorPage.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import Logo from '$lib/logos/Logo.svelte';
+
+	interface Props {
+		error?: string;
+		message?: string;
+	}
+
+	let { error = 'unknown', message = 'unknown' }: Props = $props();
+</script>
+
+<div class="grid grid-cols-3 grid-rows-3 w-full h-screen">
+	<div class="col-start-2 row-start-2 flex flex-col gap-8 items-center">
+		<div class="h-16 w-auto">
+			<Logo class="h-16 w-auto" />
+		</div>
+
+		<div class="h2">Oops, we encountered an error!</div>
+
+		<div class="grid grid-cols-2 gap-2">
+			<div class="font-bold">Status</div>
+			{error}
+			<div class="font-bold">Message</div>
+			{message}
+		</div>
+	</div>
+</div>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,22 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 
-	import Logo from '$lib/logos/Logo.svelte';
+	import ErrorPage from '$lib/layouts/ErrorPage.svelte';
 </script>
 
-<div class="grid grid-cols-3 grid-rows-3 w-full h-screen">
-	<div class="col-start-2 row-start-2 flex flex-col gap-8 items-center">
-		<div class="h-16 w-auto">
-			<Logo class="h-16 w-auto" />
-		</div>
-
-		<div class="h2">Oops, we encountered an error!</div>
-
-		<div class="grid grid-cols-2 gap-2">
-			<div class="font-bold">Status</div>
-			{page.status}
-			<div class="font-bold">Message</div>
-			{page.error?.message}
-		</div>
-	</div>
-</div>
+<ErrorPage error={page.status.toString()} message={page.error?.message} />

--- a/src/routes/error/+page.svelte
+++ b/src/routes/error/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { page } from '$app/state';
+
+	import ErrorPage from '$lib/layouts/ErrorPage.svelte';
+</script>
+
+<ErrorPage
+	error={page.url.searchParams.get('error') || undefined}
+	message={page.url.searchParams.get('message') || undefined}
+/>


### PR DESCRIPTION
This can be redirected to by identity, for example, so it can display branched error messages in the corrct client e.g. during authentication or as a result of user verification work flows.