### PR TITLE
Invalidate Race Workaround

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: v0.3.4-rc9
-appVersion: v0.3.4-rc9
+version: v0.3.4-rc10
+appVersion: v0.3.4-rc10
 
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 

--- a/src/routes/(shell)/compute/clusters/+page.svelte
+++ b/src/routes/(shell)/compute/clusters/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { invalidate, beforeNavigate } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { invalidate } from '$app/navigation';
+	import { navigating } from '$app/state';
 	import { browser } from '$app/environment';
 
 	let { data }: { data: PageData } = $props();
@@ -34,8 +36,11 @@
 		description: 'Manage your Compute clusters.'
 	};
 
-	const ticker = setInterval(() => invalidate('layout:clusters'), 5000);
-	beforeNavigate(() => clearInterval(ticker));
+	onMount(() => {
+		const interval = setInterval(() => navigating.to || invalidate('layout:clusters'), 5000);
+
+		return () => clearInterval(interval);
+	});
 
 	let groups = $derived.by(() => {
 		let temp: Record<string, Array<Compute.ComputeClusterRead>> = {};

--- a/src/routes/(shell)/identity/groups/+page.svelte
+++ b/src/routes/(shell)/identity/groups/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { invalidate, beforeNavigate } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { invalidate } from '$app/navigation';
+	import { navigating } from '$app/state';
 
 	let { data }: { data: PageData } = $props();
 
@@ -29,8 +31,11 @@
 		description: 'Manage your organizations groups and roles.'
 	};
 
-	const ticker = setInterval(() => invalidate('page:groups'), 5000);
-	beforeNavigate(() => clearInterval(ticker));
+	onMount(() => {
+		const interval = setInterval(() => navigating.to || invalidate('layout:groups'), 5000);
+
+		return () => clearInterval(interval);
+	});
 
 	function remove(resource: Identity.GroupRead) {
 		const modal: ModalSettings = {

--- a/src/routes/(shell)/identity/oauth2providers/+page.svelte
+++ b/src/routes/(shell)/identity/oauth2providers/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { invalidate, beforeNavigate } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { invalidate } from '$app/navigation';
+	import { navigating } from '$app/state';
 
 	let { data }: { data: PageData } = $props();
 
@@ -29,8 +31,11 @@
 		description: 'Manage your OAuth2 providers.'
 	};
 
-	const ticker = setInterval(() => invalidate('layout:oauth2providers'), 5000);
-	beforeNavigate(() => clearInterval(ticker));
+	onMount(() => {
+		const interval = setInterval(() => navigating.to || invalidate('layout:oauth2providers'), 5000);
+
+		return () => clearInterval(interval);
+	});
 
 	function remove(resource: Identity.Oauth2ProviderRead): void {
 		const modal: ModalSettings = {

--- a/src/routes/(shell)/identity/projects/+page.svelte
+++ b/src/routes/(shell)/identity/projects/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { invalidate, beforeNavigate } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { invalidate } from '$app/navigation';
+	import { navigating } from '$app/state';
 
 	let { data }: { data: PageData } = $props();
 
@@ -29,8 +31,11 @@
 		description: 'Manage your resources.'
 	};
 
-	const ticker = setInterval(() => invalidate('layout:projects'), 5000);
-	beforeNavigate(() => clearInterval(ticker));
+	onMount(() => {
+		const interval = setInterval(() => navigating.to || invalidate('layout:projects'), 5000);
+
+		return () => clearInterval(interval);
+	});
 
 	function remove(resource: Identity.ProjectRead): void {
 		const modal: ModalSettings = {

--- a/src/routes/(shell)/identity/serviceaccounts/+page.svelte
+++ b/src/routes/(shell)/identity/serviceaccounts/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { invalidate, beforeNavigate } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { invalidate } from '$app/navigation';
+	import { navigating } from '$app/state';
 
 	let { data }: { data: PageData } = $props();
 
@@ -30,8 +32,11 @@
 		description: "Manage your organization's service accounts."
 	};
 
-	const ticker = setInterval(() => invalidate('layout:serviceaccounts'), 5000);
-	beforeNavigate(() => clearInterval(ticker));
+	onMount(() => {
+		const interval = setInterval(() => navigating.to || invalidate('layout:serviceaccounts'), 5000);
+
+		return () => clearInterval(interval);
+	});
 
 	function remove(resource: Identity.ServiceAccountRead) {
 		const modal: ModalSettings = {

--- a/src/routes/(shell)/identity/users/+page.svelte
+++ b/src/routes/(shell)/identity/users/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { invalidate, beforeNavigate } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { invalidate } from '$app/navigation';
+	import { navigating } from '$app/state';
 
 	let { data }: { data: PageData } = $props();
 
@@ -31,8 +33,11 @@
 		description: "Manage your organization's users."
 	};
 
-	const ticker = setInterval(() => invalidate('layout:users'), 5000);
-	beforeNavigate(() => clearInterval(ticker));
+	onMount(() => {
+		const interval = setInterval(() => navigating.to || invalidate('layout:users'), 5000);
+
+		return () => clearInterval(interval);
+	});
 
 	function remove(resource: Identity.UserRead) {
 		const modal: ModalSettings = {

--- a/src/routes/(shell)/kubernetes/clustermanagers/+page.svelte
+++ b/src/routes/(shell)/kubernetes/clustermanagers/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { invalidate, beforeNavigate } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { invalidate } from '$app/navigation';
+	import { navigating } from '$app/state';
 
 	let { data }: { data: PageData } = $props();
 
@@ -28,8 +30,11 @@
 		description: 'Manage your Kubernetes cluster life-cycle managers.'
 	};
 
-	const ticker = setInterval(() => invalidate('layout:clustermanagers'), 5000);
-	beforeNavigate(() => clearInterval(ticker));
+	onMount(() => {
+		const interval = setInterval(() => navigating.to || invalidate('layout:clustermanagers'), 5000);
+
+		return () => clearInterval(interval);
+	});
 
 	function remove(resource: Kubernetes.ClusterManagerRead): void {
 		const modal: ModalSettings = {

--- a/src/routes/(shell)/kubernetes/clusters/+page.svelte
+++ b/src/routes/(shell)/kubernetes/clusters/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { invalidate, beforeNavigate } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { invalidate } from '$app/navigation';
+	import { navigating } from '$app/state';
 	import { browser } from '$app/environment';
 
 	let { data }: { data: PageData } = $props();
@@ -33,8 +35,11 @@
 		description: 'Manage your Kubernetes clusters.'
 	};
 
-	const ticker = setInterval(() => invalidate('layout:clusters'), 5000);
-	beforeNavigate(() => clearInterval(ticker));
+	onMount(() => {
+		const interval = setInterval(() => navigating.to || invalidate('layout:clusters'), 5000);
+
+		return () => clearInterval(interval);
+	});
 
 	let groups = $derived.by(() => {
 		let temp: Record<string, Array<Kubernetes.KubernetesClusterRead>> = {};

--- a/src/routes/(shell)/regions/identities/+page.svelte
+++ b/src/routes/(shell)/regions/identities/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { invalidate, beforeNavigate } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { invalidate } from '$app/navigation';
+	import { navigating } from '$app/state';
 
 	let { data }: { data: PageData } = $props();
 
@@ -30,8 +32,11 @@
 		description: 'Manage your cloud identities'
 	};
 
-	const ticker = setInterval(() => invalidate('layout:identities'), 5000);
-	beforeNavigate(() => clearInterval(ticker));
+	onMount(() => {
+		const interval = setInterval(() => navigating.to || invalidate('layout:identities'), 5000);
+
+		return () => clearInterval(interval);
+	});
 
 	function remove(resource: Region.IdentityRead): void {
 		const modal: ModalSettings = {

--- a/src/routes/(shell)/regions/networks/+page.svelte
+++ b/src/routes/(shell)/regions/networks/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { PageData } from './$types';
-	import { invalidate, beforeNavigate } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { invalidate } from '$app/navigation';
+	import { navigating } from '$app/state';
 
 	let { data }: { data: PageData } = $props();
 
@@ -22,8 +24,11 @@
 		description: 'Manage your networks'
 	};
 
-	const ticker = setInterval(() => invalidate('layout:networks'), 5000);
-	beforeNavigate(() => clearInterval(ticker));
+	onMount(() => {
+		const interval = setInterval(() => navigating.to || invalidate('layout:networks'), 5000);
+
+		return () => clearInterval(interval);
+	});
 </script>
 
 <ShellPage {settings} allowed={data.allowed}>


### PR DESCRIPTION
What feels like a proper fix for the prior commit.  Based on feedback from https://github.com/sveltejs/kit/issues/9354 it appears Svelte gives up if an invalidation happens during a navigation.  Now the user could reclick the button until it works, but it's not intuitive.  Even worse for us, we have a full screen div blocking the UI indicating something is happening!