### PR TITLE
Reimagine Multiselects

### DIFF
--- a/src/lib/forms/MultiSelect.svelte
+++ b/src/lib/forms/MultiSelect.svelte
@@ -1,4 +1,11 @@
 <script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	import type { AutocompleteOption, PopupSettings } from '@skeletonlabs/skeleton';
+	import { Autocomplete, popup } from '@skeletonlabs/skeleton';
+
+	import type { SizeOptions } from '@floating-ui/dom';
+
 	interface Props {
 		// Unique element ID.
 		id: string;
@@ -8,10 +15,36 @@
 		label: string;
 		// Formatting hint.
 		hint?: string;
-		children?: import('svelte').Snippet;
+		// List of all possible options.
+		options: Array<AutocompleteOption<string>>;
+		// Member addition callback.
+		add: (value: string) => void;
+		// Member remove callback.
+		remove: (index: number) => void;
+		// Rendering snippet for a selected item.
+		selected: Snippet<[string]>;
 	}
 
-	let { id, value = $bindable(), label, hint = '', children }: Props = $props();
+	let { id, value, label, hint = '', options, add, remove, selected }: Props = $props();
+
+	let svalue = $state();
+
+	const sizeOptions: SizeOptions = {
+		apply({ rects, elements }) {
+			Object.assign(elements.floating.style, {
+				minWidth: `${rects.reference.width}px`
+			});
+		}
+	};
+
+	const popupSettings: PopupSettings = {
+		event: 'focus-click',
+		target: 'popupAutocomplete-' + id,
+		placement: 'bottom-start',
+		middleware: {
+			size: sizeOptions
+		}
+	};
 </script>
 
 <div class="flex flex-col gap-4">
@@ -23,7 +56,35 @@
 		{/if}
 	</div>
 
-	<select {id} class="select shadow-lg" multiple bind:value>
-		{@render children?.()}
-	</select>
+	<div class="flex flex-col gap-2">
+		{#each value as v, i}
+			<div class="card shadow-lg bg-surface-50-900-token flex justify-between items-center p-4">
+				{@render selected(v)}
+				<button onclick={() => remove(i)} onkeypress={() => remove(i)} aria-label="Remove item">
+					<iconify-icon icon="mdi:trash-can-outline" class="text-xl text-primary-500"
+					></iconify-icon>
+				</button>
+			</div>
+		{/each}
+	</div>
+
+	<div class="inline-flex flex-col">
+		<input
+			class="input"
+			type="search"
+			name={id}
+			bind:value={svalue}
+			placeholder="Search..."
+			use:popup={popupSettings}
+		/>
+
+		<div class="card p-4 shadow-lg max-h-32 overflow-y-auto" data-popup={'popupAutocomplete-' + id}>
+			<Autocomplete
+				bind:input={svalue}
+				{options}
+				denylist={value}
+				on:selection={(event: CustomEvent<AutocompleteOption<string>>) => add(event.detail.value)}
+			/>
+		</div>
+	</div>
 </div>

--- a/src/lib/openapi/identity/models/GroupSpec.ts
+++ b/src/lib/openapi/identity/models/GroupSpec.ts
@@ -24,13 +24,13 @@ export interface GroupSpec {
      * @type {Array<string>}
      * @memberof GroupSpec
      */
-    userIDs?: Array<string>;
+    userIDs: Array<string>;
     /**
      * A list of strings.
      * @type {Array<string>}
      * @memberof GroupSpec
      */
-    serviceAccountIDs?: Array<string>;
+    serviceAccountIDs: Array<string>;
     /**
      * A list of strings.
      * @type {Array<string>}
@@ -44,6 +44,8 @@ export interface GroupSpec {
  */
 export function instanceOfGroupSpec(value: object): boolean {
     let isInstance = true;
+    isInstance = isInstance && "userIDs" in value;
+    isInstance = isInstance && "serviceAccountIDs" in value;
     isInstance = isInstance && "roleIDs" in value;
 
     return isInstance;
@@ -59,8 +61,8 @@ export function GroupSpecFromJSONTyped(json: any, ignoreDiscriminator: boolean):
     }
     return {
         
-        'userIDs': !exists(json, 'userIDs') ? undefined : json['userIDs'],
-        'serviceAccountIDs': !exists(json, 'serviceAccountIDs') ? undefined : json['serviceAccountIDs'],
+        'userIDs': json['userIDs'],
+        'serviceAccountIDs': json['serviceAccountIDs'],
         'roleIDs': json['roleIDs'],
     };
 }

--- a/src/lib/openapi/identity/models/ProjectSpec.ts
+++ b/src/lib/openapi/identity/models/ProjectSpec.ts
@@ -24,7 +24,7 @@ export interface ProjectSpec {
      * @type {Array<string>}
      * @memberof ProjectSpec
      */
-    groupIDs?: Array<string>;
+    groupIDs: Array<string>;
 }
 
 /**
@@ -32,6 +32,7 @@ export interface ProjectSpec {
  */
 export function instanceOfProjectSpec(value: object): boolean {
     let isInstance = true;
+    isInstance = isInstance && "groupIDs" in value;
 
     return isInstance;
 }
@@ -46,7 +47,7 @@ export function ProjectSpecFromJSONTyped(json: any, ignoreDiscriminator: boolean
     }
     return {
         
-        'groupIDs': !exists(json, 'groupIDs') ? undefined : json['groupIDs'],
+        'groupIDs': json['groupIDs'],
     };
 }
 

--- a/src/lib/openapi/identity/models/ServiceAccountCreate.ts
+++ b/src/lib/openapi/identity/models/ServiceAccountCreate.ts
@@ -49,7 +49,7 @@ export interface ServiceAccountCreate {
      * @type {ServiceAccountSpec}
      * @memberof ServiceAccountCreate
      */
-    spec?: ServiceAccountSpec;
+    spec: ServiceAccountSpec;
     /**
      * 
      * @type {ServiceAccountStatus}
@@ -64,6 +64,7 @@ export interface ServiceAccountCreate {
 export function instanceOfServiceAccountCreate(value: object): boolean {
     let isInstance = true;
     isInstance = isInstance && "metadata" in value;
+    isInstance = isInstance && "spec" in value;
     isInstance = isInstance && "status" in value;
 
     return isInstance;
@@ -80,7 +81,7 @@ export function ServiceAccountCreateFromJSONTyped(json: any, ignoreDiscriminator
     return {
         
         'metadata': OrganizationScopedResourceReadMetadataFromJSON(json['metadata']),
-        'spec': !exists(json, 'spec') ? undefined : ServiceAccountSpecFromJSON(json['spec']),
+        'spec': ServiceAccountSpecFromJSON(json['spec']),
         'status': ServiceAccountStatusFromJSON(json['status']),
     };
 }

--- a/src/lib/openapi/identity/models/ServiceAccountRead.ts
+++ b/src/lib/openapi/identity/models/ServiceAccountRead.ts
@@ -49,7 +49,7 @@ export interface ServiceAccountRead {
      * @type {ServiceAccountSpec}
      * @memberof ServiceAccountRead
      */
-    spec?: ServiceAccountSpec;
+    spec: ServiceAccountSpec;
     /**
      * 
      * @type {ServiceAccountStatus}
@@ -64,6 +64,7 @@ export interface ServiceAccountRead {
 export function instanceOfServiceAccountRead(value: object): boolean {
     let isInstance = true;
     isInstance = isInstance && "metadata" in value;
+    isInstance = isInstance && "spec" in value;
     isInstance = isInstance && "status" in value;
 
     return isInstance;
@@ -80,7 +81,7 @@ export function ServiceAccountReadFromJSONTyped(json: any, ignoreDiscriminator: 
     return {
         
         'metadata': OrganizationScopedResourceReadMetadataFromJSON(json['metadata']),
-        'spec': !exists(json, 'spec') ? undefined : ServiceAccountSpecFromJSON(json['spec']),
+        'spec': ServiceAccountSpecFromJSON(json['spec']),
         'status': ServiceAccountStatusFromJSON(json['status']),
     };
 }

--- a/src/lib/openapi/identity/models/ServiceAccountSpec.ts
+++ b/src/lib/openapi/identity/models/ServiceAccountSpec.ts
@@ -24,7 +24,7 @@ export interface ServiceAccountSpec {
      * @type {Array<string>}
      * @memberof ServiceAccountSpec
      */
-    groupIDs?: Array<string>;
+    groupIDs: Array<string>;
 }
 
 /**
@@ -32,6 +32,7 @@ export interface ServiceAccountSpec {
  */
 export function instanceOfServiceAccountSpec(value: object): boolean {
     let isInstance = true;
+    isInstance = isInstance && "groupIDs" in value;
 
     return isInstance;
 }
@@ -46,7 +47,7 @@ export function ServiceAccountSpecFromJSONTyped(json: any, ignoreDiscriminator: 
     }
     return {
         
-        'groupIDs': !exists(json, 'groupIDs') ? undefined : json['groupIDs'],
+        'groupIDs': json['groupIDs'],
     };
 }
 

--- a/src/lib/openapi/identity/models/ServiceAccountWrite.ts
+++ b/src/lib/openapi/identity/models/ServiceAccountWrite.ts
@@ -43,7 +43,7 @@ export interface ServiceAccountWrite {
      * @type {ServiceAccountSpec}
      * @memberof ServiceAccountWrite
      */
-    spec?: ServiceAccountSpec;
+    spec: ServiceAccountSpec;
 }
 
 /**
@@ -52,6 +52,7 @@ export interface ServiceAccountWrite {
 export function instanceOfServiceAccountWrite(value: object): boolean {
     let isInstance = true;
     isInstance = isInstance && "metadata" in value;
+    isInstance = isInstance && "spec" in value;
 
     return isInstance;
 }
@@ -67,7 +68,7 @@ export function ServiceAccountWriteFromJSONTyped(json: any, ignoreDiscriminator:
     return {
         
         'metadata': ResourceWriteMetadataFromJSON(json['metadata']),
-        'spec': !exists(json, 'spec') ? undefined : ServiceAccountSpecFromJSON(json['spec']),
+        'spec': ServiceAccountSpecFromJSON(json['spec']),
     };
 }
 

--- a/src/routes/(shell)/identity/groups/create/+page.svelte
+++ b/src/routes/(shell)/identity/groups/create/+page.svelte
@@ -3,6 +3,7 @@
 
 	let { data }: { data: PageData } = $props();
 
+	import type { AutocompleteOption } from '@skeletonlabs/skeleton';
 	import { getToastStore } from '@skeletonlabs/skeleton';
 
 	const toastStore = getToastStore();
@@ -52,6 +53,24 @@
 			.then(() => window.location.assign('/identity/groups'))
 			.catch((e: Error) => Clients.error(toastStore, e));
 	}
+
+	let roles = $derived(
+		data.roles.map(
+			(x) => ({ label: x.metadata.name, value: x.metadata.id }) as AutocompleteOption<string>
+		)
+	);
+
+	let users = $derived(
+		data.users.map(
+			(x) => ({ label: x.spec.subject, value: x.metadata.id }) as AutocompleteOption<string>
+		)
+	);
+
+	let serviceAccounts = $derived(
+		data.serviceAccounts.map(
+			(x) => ({ label: x.metadata.name, value: x.metadata.id }) as AutocompleteOption<string>
+		)
+	);
 </script>
 
 <ShellPage {settings}>
@@ -62,36 +81,45 @@
 			id="role-ids"
 			label="Select roles for group members."
 			hint="You must select at least one role."
-			bind:value={resource.spec.roleIDs}
+			options={roles}
+			value={resource.spec.roleIDs}
+			add={(value: string) => resource.spec.roleIDs.push(value)}
+			remove={(index: number) => resource.spec.roleIDs.splice(index, 1)}
 		>
-			{#each data.roles as role}
-				<option value={role.metadata.id}>{role.metadata.name}</option>
-			{/each}
+			{#snippet selected(value: string)}
+				{data.roles.find((x) => x.metadata.id == value)?.metadata.name}
+			{/snippet}
 		</MultiSelect>
 	</ShellSection>
 
 	<ShellSection title="Users">
-		{#if resource.spec.userIDs}
-			<MultiSelect id="user-ids" label="Select group members." bind:value={resource.spec.userIDs}>
-				{#each data.users as user}
-					<option value={user.metadata.id}>{user.spec.subject}</option>
-				{/each}
-			</MultiSelect>
-		{/if}
+		<MultiSelect
+			id="user-ids"
+			label="Select group members."
+			options={users}
+			value={resource.spec.userIDs}
+			add={(value: string) => resource.spec.userIDs.push(value)}
+			remove={(index: number) => resource.spec.userIDs.splice(index, 1)}
+		>
+			{#snippet selected(value: string)}
+				{data.users.find((x) => x.metadata.id == value)?.spec.subject}
+			{/snippet}
+		</MultiSelect>
 	</ShellSection>
 
 	<ShellSection title="Service Accounts">
-		{#if resource.spec.serviceAccountIDs}
-			<MultiSelect
-				id="sa-ids"
-				label="Select group members."
-				bind:value={resource.spec.serviceAccountIDs}
-			>
-				{#each data.serviceAccounts as serviceAccount}
-					<option value={serviceAccount.metadata.id}>{serviceAccount.metadata.name}</option>
-				{/each}
-			</MultiSelect>
-		{/if}
+		<MultiSelect
+			id="sa-ids"
+			label="Select group members."
+			options={serviceAccounts}
+			value={resource.spec.serviceAccountIDs}
+			add={(value: string) => resource.spec.serviceAccountIDs.push(value)}
+			remove={(index: number) => resource.spec.serviceAccountIDs.splice(index, 1)}
+		>
+			{#snippet selected(value: string)}
+				{data.serviceAccounts.find((x) => x.metadata.id == value)?.metadata.name}
+			{/snippet}
+		</MultiSelect>
 	</ShellSection>
 
 	<div class="flex justify-between">

--- a/src/routes/(shell)/identity/projects/create/+page.svelte
+++ b/src/routes/(shell)/identity/projects/create/+page.svelte
@@ -3,6 +3,7 @@
 
 	let { data }: { data: PageData } = $props();
 
+	import type { AutocompleteOption } from '@skeletonlabs/skeleton';
 	import { getToastStore } from '@skeletonlabs/skeleton';
 
 	const toastStore = getToastStore();
@@ -52,6 +53,12 @@
 			.then(() => window.location.assign('/identity/projects'))
 			.catch((e: Error) => Clients.error(toastStore, e));
 	}
+
+	let groups = $derived(
+		data.groups.map(
+			(x) => ({ label: x.metadata.name, value: x.metadata.id }) as AutocompleteOption<string>
+		)
+	);
 </script>
 
 <ShellPage {settings}>
@@ -62,11 +69,14 @@
 			id="group-ids"
 			label="Select group access."
 			hint="Groups associate users with projects and grant them permissions to create, view, edit and delete."
-			bind:value={resource.spec.groupIDs as Array<string>}
+			options={groups}
+			value={resource.spec.groupIDs}
+			add={(value: string) => resource.spec.groupIDs.push(value)}
+			remove={(index: number) => resource.spec.groupIDs.splice(index, 1)}
 		>
-			{#each data.groups as group}
-				<option value={group.metadata.id}>{group.metadata.name}</option>
-			{/each}
+			{#snippet selected(value: string)}
+				{data.groups.find((x) => x.metadata.id == value)?.metadata.name}
+			{/snippet}
 		</MultiSelect>
 	</ShellSection>
 

--- a/src/routes/(shell)/identity/serviceaccounts/create/+page.svelte
+++ b/src/routes/(shell)/identity/serviceaccounts/create/+page.svelte
@@ -3,6 +3,7 @@
 
 	let { data }: { data: PageData } = $props();
 
+	import type { AutocompleteOption } from '@skeletonlabs/skeleton';
 	import { getToastStore } from '@skeletonlabs/skeleton';
 
 	const toastStore = getToastStore();
@@ -54,6 +55,12 @@
 			.then((v: Identity.ServiceAccountCreate) => (serviceAccount = v))
 			.catch((e: Error) => Clients.error(toastStore, e));
 	}
+
+	let groups = $derived(
+		data.groups.map(
+			(x) => ({ label: x.metadata.name, value: x.metadata.id }) as AutocompleteOption<string>
+		)
+	);
 </script>
 
 <ShellPage {settings}>
@@ -79,20 +86,19 @@
 		<ShellMetadataSection metadata={resource.metadata} {names} bind:valid={metadataValid} />
 
 		<ShellSection title="Access Control">
-			{#if resource.spec?.groupIDs}
-				<MultiSelect
-					id="sa-groups"
-					label="Groups"
-					hint="Select any groups that the service account should be a member of."
-					bind:value={resource.spec.groupIDs}
-				>
-					{#each data.groups as group}
-						<option value={group.metadata.id}>
-							{group.metadata.name}
-						</option>
-					{/each}
-				</MultiSelect>
-			{/if}
+			<MultiSelect
+				id="group-ids"
+				label="Select group access."
+				hint="Groups associate users with projects and grant them permissions to create, view, edit and delete."
+				options={groups}
+				value={resource.spec.groupIDs}
+				add={(value: string) => resource.spec.groupIDs.push(value)}
+				remove={(index: number) => resource.spec.groupIDs.splice(index, 1)}
+			>
+				{#snippet selected(value: string)}
+					{data.groups.find((x) => x.metadata.id == value)?.metadata.name}
+				{/snippet}
+			</MultiSelect>
 		</ShellSection>
 
 		<div class="flex justify-between">

--- a/src/routes/(shell)/identity/users/create/+page.svelte
+++ b/src/routes/(shell)/identity/users/create/+page.svelte
@@ -3,6 +3,7 @@
 
 	let { data }: { data: PageData } = $props();
 
+	import type { AutocompleteOption } from '@skeletonlabs/skeleton';
 	import { getToastStore } from '@skeletonlabs/skeleton';
 
 	const toastStore = getToastStore();
@@ -50,6 +51,12 @@
 			.then(() => window.location.assign('/identity/users'))
 			.catch((e: Error) => Clients.error(toastStore, e));
 	}
+
+	let groups = $derived(
+		data.groups.map(
+			(x) => ({ label: x.metadata.name, value: x.metadata.id }) as AutocompleteOption<string>
+		)
+	);
 </script>
 
 <ShellPage {settings}>
@@ -65,20 +72,19 @@
 	</ShellSection>
 
 	<ShellSection title="Access Control">
-		{#if resource.spec.groupIDs}
-			<MultiSelect
-				id="sa-groups"
-				label="Groups"
-				hint="Select at least one group that the user should be a member of."
-				bind:value={resource.spec.groupIDs}
-			>
-				{#each data.groups as group}
-					<option value={group.metadata.id}>
-						{group.metadata.name}
-					</option>
-				{/each}
-			</MultiSelect>
-		{/if}
+		<MultiSelect
+			id="group-ids"
+			label="Select group access."
+			hint="Groups associate users with projects and grant them permissions to create, view, edit and delete."
+			options={groups}
+			value={resource.spec.groupIDs}
+			add={(value: string) => resource.spec.groupIDs.push(value)}
+			remove={(index: number) => resource.spec.groupIDs.splice(index, 1)}
+		>
+			{#snippet selected(value: string)}
+				{data.groups.find((x) => x.metadata.id == value)?.metadata.name}
+			{/snippet}
+		</MultiSelect>
 	</ShellSection>
 
 	<div class="flex justify-between">


### PR DESCRIPTION
With really long lists of users and groups and stuff we really want to limit the list sizes, provide a search function and easily be able to see who or what is selected without having to scroll down an entire list.  To the rescue comes Autocomplete.

Fixes #146.