### PR TITLE
Fix Shell List Metadata

### DIFF
--- a/src/lib/layouts/ShellListItemMetadata.svelte
+++ b/src/lib/layouts/ShellListItemMetadata.svelte
@@ -7,23 +7,27 @@
 	import ShellMetadataItem from '$lib/layouts/ShellMetadataItem.svelte';
 
 	interface Props {
-		metadata: Kubernetes.ResourceReadMetadata;
-		extra?: Snippet;
+		metadata?: Kubernetes.ResourceReadMetadata;
+		children?: Snippet;
 	}
 
-	let { metadata, extra }: Props = $props();
+	let { metadata, children }: Props = $props();
 </script>
 
-<div class="grid grid-cols-[repeat(3,max-content)] gap-2 text-sm items-center">
-	<ShellMetadataItem
-		icon="mdi:clock-time-five-outline"
-		label="Age"
-		value={Formatters.ageFormatter(metadata.creationTime)}
-	/>
+<div class="grid grid-cols-[repeat(3,max-content)] gap-2 text-sm self-start">
+	{#if metadata}
+		<ShellMetadataItem
+			icon="mdi:clock-time-five-outline"
+			label="Age"
+			value={Formatters.ageFormatter(metadata.creationTime)}
+		/>
 
-	{#if metadata.createdBy}
-		<ShellMetadataItem icon="mdi:user-outline" label="Owner" value={metadata.createdBy} />
+		<ShellMetadataItem
+			icon="mdi:user-outline"
+			label="Owner"
+			value={metadata.createdBy || 'unknown'}
+		/>
 	{/if}
 
-	{@render extra?.()}
+	{@render children?.()}
 </div>

--- a/src/routes/(shell)/identity/serviceaccounts/+page.svelte
+++ b/src/routes/(shell)/identity/serviceaccounts/+page.svelte
@@ -80,14 +80,14 @@
 
 				<ShellListItemBadges metadata={resource.metadata} />
 
-				<ShellListItemMetadata metadata={resource.metadata}>
-					{#snippet extra()}
-						<ShellMetadataItem
-							icon="mdi:key-outline"
-							label="Expiry"
-							value={resource.status.expiry.toUTCString()}
-						/>
-					{/snippet}
+				<ShellListItemMetadata metadata={resource.metadata} />
+
+				<ShellListItemMetadata>
+					<ShellMetadataItem
+						icon="mdi:key-outline"
+						label="Expiry"
+						value={resource.status.expiry.toUTCString()}
+					/>
 				</ShellListItemMetadata>
 
 				{#snippet trail()}

--- a/src/routes/(shell)/identity/users/+page.svelte
+++ b/src/routes/(shell)/identity/users/+page.svelte
@@ -118,14 +118,10 @@
 					{/snippet}
 				</ShellListItemBadges>
 
-				<ShellListItemMetadata metadata={resource.metadata}>
-					{#snippet extra()}
-						<ShellMetadataItem
-							icon="mdi:run"
-							label="Last Active"
-							value={userLastActive(resource)}
-						/>
-					{/snippet}
+				<ShellListItemMetadata metadata={resource.metadata} />
+
+				<ShellListItemMetadata>
+					<ShellMetadataItem icon="mdi:run" label="Last Active" value={userLastActive(resource)} />
 				</ShellListItemMetadata>
 
 				{#snippet trail()}

--- a/src/routes/(shell)/regions/networks/+page.svelte
+++ b/src/routes/(shell)/regions/networks/+page.svelte
@@ -47,26 +47,26 @@
 					{/snippet}
 				</ShellListItemBadges>
 
-				<ShellListItemMetadata metadata={resource.metadata}>
-					{#snippet extra()}
+				<ShellListItemMetadata metadata={resource.metadata} />
+
+				<ShellListItemMetadata>
+					<ShellMetadataItem
+						icon="mdi:network-outline"
+						label="Prefix"
+						value={resource.spec.prefix}
+					/>
+					<ShellMetadataItem
+						icon="mdi:dns-outline"
+						label="DNS Nameservers"
+						value={resource.spec.dnsNameservers.join(', ')}
+					/>
+					{#if resource.spec.openstack?.vlanId}
 						<ShellMetadataItem
-							icon="mdi:network-outline"
-							label="Prefix"
-							value={resource.spec.prefix}
+							icon="mdi:nic"
+							label="VLAN ID"
+							value={resource.spec.openstack.vlanId.toString()}
 						/>
-						<ShellMetadataItem
-							icon="mdi:dns-outline"
-							label="DNS Nameservers"
-							value={resource.spec.dnsNameservers.join(', ')}
-						/>
-						{#if resource.spec.openstack?.vlanId}
-							<ShellMetadataItem
-								icon="mdi:nic"
-								label="VLAN ID"
-								value={resource.spec.openstack.vlanId.toString()}
-							/>
-						{/if}
-					{/snippet}
+					{/if}
 				</ShellListItemMetadata>
 			</ShellListItem>
 		{/each}


### PR DESCRIPTION
Make it so things are visually the same everywhere e.g. fill in blanks rather than not render anything.  Split multiple metadata options across multiple grid columns to compact the view.