### PR TITLE
Allow Client ID/Secret From a Secret

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: v0.3.9
-appVersion: v0.3.9
+version: v0.3.10-rc1
+appVersion: v0.3.10-rc1
 
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 

--- a/charts/ui/templates/deployment.yaml
+++ b/charts/ui/templates/deployment.yaml
@@ -40,18 +40,18 @@ spec:
           value: https://{{ include "unikorn.application.host" . }}
         - name: PUBLIC_COMPUTE_HOST
           value: https://{{ include "unikorn.compute.host" . }}
-        - name: OIDC_CLIENT_ID
-          {{- if .Values.oauth2.clientName }}
-          value: {{ include "resource.id" .Values.oauth2.clientName }}
-          {{- else }}
-          value: {{ .Values.oauth2.clientID }}
-          {{- end }}
-        - name: OIDC_CLIENT_SECRET
-          value: {{ .Values.oauth2.clientSecret }}
         {{- if .Values.tls.private }}
         - name: NODE_EXTRA_CA_CERTS
           value: /var/run/secrets/unikorn-cloud.org/ca.crt
         {{- end }}
+        envFrom:
+        - secretRef:
+            {{- if .Values.oauth2.clientSecretSecretName }}
+            name: {{ .Values.oauth2.clientSecretSecretName }}
+            {{- else }}
+            name: unikorn-ui-oidc-secret
+            {{- end }}
+            optional: false
         securityContext:
           readOnlyRootFilesystem: true
         {{- if .Values.tls.private }}

--- a/charts/ui/templates/secret.yaml
+++ b/charts/ui/templates/secret.yaml
@@ -1,0 +1,10 @@
+{{- if not .Values.oauth2.clientSecretSecretName }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: unikorn-ui-oidc-secret
+type: Opaque
+data:
+  OIDC_CLIENT_ID: {{ b64enc .Values.oauth2.clientID }}
+  OIDC_CLIENT_SECRET: {{ b64enc .Values.oauth2.clientSecret }}
+{{- end }}

--- a/charts/ui/values.yaml
+++ b/charts/ui/values.yaml
@@ -51,9 +51,9 @@ oauth2:
   clientID: 3fc34852-9186-4884-b580-78bf4bcf628a
   # The client secret.
   clientSecret: yoz}wepat4Shmy
-  # The client name, which can be shared with the identity configuration
-  # and then hashed into a predictlable ID.  Overrides the ID.
-  # clientName: foo
+  # The client ID/secret sourced from a secret.  This trumps the normal clientID/clientSecret
+  # configuration.  Must contain the keys OIDC_CLIENT_ID and OIDC_CLIENT_SECRET.
+  # clientSecretSecretName: my-client-secret
 
 tls:
   # When marked as private, this will mount the ingress secret into the


### PR DESCRIPTION
And it always comes from a secret so you can control who can see it via Kyverno and friends.  We lose the convenience method of supplying a client name as you need to supply a secret anyway, so may as well grab that at the same time.  You can also override secret creation and supply your own from the External Secrets Operator etc.