### PR TITLE
Use folder icon for Project items

### DIFF
--- a/src/routes/(shell)/identity/projects/+page.svelte
+++ b/src/routes/(shell)/identity/projects/+page.svelte
@@ -50,7 +50,7 @@
 
 	<ShellList>
 		{#each data.projects || [] as resource}
-			<ShellListItem icon="mdi:account-group-outline">
+			<ShellListItem icon="mdi:folder-open-outline">
 				{#snippet main()}
 					<ShellListItemHeader
 						metadata={resource.metadata}


### PR DESCRIPTION
(...rather than the group icon again)

Fixes #201.