### PR TITLE
Use folder-open icon for projects

### DIFF
--- a/src/lib/layouts/ShellListItemHeader.svelte
+++ b/src/lib/layouts/ShellListItemHeader.svelte
@@ -33,7 +33,7 @@
 	<header class="flex flex-col gap-1">
 		{#if project}
 			<div class="flex gap-2 items-center tex-sm overflow-hidden text-ellipsis whitespace-nowrap">
-				<iconify-icon icon="mdi:account-group-outline"></iconify-icon>
+				<iconify-icon icon="mdi:folder-open-outline"></iconify-icon>
 				{project}
 			</div>
 		{/if}

--- a/src/routes/(shell)/compute/clusters/+page.svelte
+++ b/src/routes/(shell)/compute/clusters/+page.svelte
@@ -83,7 +83,7 @@
 						<div class="font-bold">Project</div>
 
 						<div class="input-group grid grid-cols-[auto_1fr]">
-							<iconify-icon icon="mdi:account-group-outline" class="ig-cell"></iconify-icon>
+							<iconify-icon icon="mdi:folder-open-outline" class="ig-cell"></iconify-icon>
 
 							<select class="ig-select" bind:value={createProjectID}>
 								{#each data.projects as p}

--- a/src/routes/(shell)/kubernetes/clusters/+page.svelte
+++ b/src/routes/(shell)/kubernetes/clusters/+page.svelte
@@ -97,7 +97,7 @@
 						<div class="font-bold">Project</div>
 
 						<div class="input-group grid grid-cols-[auto_1fr]">
-							<iconify-icon icon="mdi:account-group-outline" class="ig-cell"></iconify-icon>
+							<iconify-icon icon="mdi:folder-open-outline" class="ig-cell"></iconify-icon>
 
 							<select class="ig-select" bind:value={createProjectID}>
 								{#each data.projects as p}

--- a/src/routes/(shell)/kubernetes/virtualclusters/+page.svelte
+++ b/src/routes/(shell)/kubernetes/virtualclusters/+page.svelte
@@ -97,7 +97,7 @@
 						<div class="font-bold">Project</div>
 
 						<div class="input-group grid grid-cols-[auto_1fr]">
-							<iconify-icon icon="mdi:account-group-outline" class="ig-cell"></iconify-icon>
+							<iconify-icon icon="mdi:folder-open-outline" class="ig-cell"></iconify-icon>
 
 							<select class="ig-select" bind:value={createProjectID}>
 								{#each data.projects as p}


### PR DESCRIPTION
This replaces the account-group icon with the folder-open icon wherever the icon is representing a project rather than an account group.