### PR TITLE
Fix Token Refresh

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: v0.3.16-rc1
-appVersion: v0.3.16-rc1
+version: v0.3.16-rc2
+appVersion: v0.3.16-rc2
 
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 

--- a/src/lib/shell/SideBar.svelte
+++ b/src/lib/shell/SideBar.svelte
@@ -14,14 +14,13 @@
 	import * as RBAC from '$lib/rbac';
 
 	interface Props {
-		token: InternalToken;
 		organizations: Array<Identity.OrganizationRead>;
 		organizationID: string;
 		acl: Identity.Acl;
 		onClicked?: () => void;
 	}
 
-	let { token, organizations, organizationID, acl, onClicked }: Props = $props();
+	let { organizations, organizationID, acl, onClicked }: Props = $props();
 
 	type NavItems = Array<{ label: string; href: string; rbac?: Array<RBAC.OrganizationScope> }>;
 	type Nav = Array<{ base: string; title: string; icon: string; items: NavItems }>;

--- a/src/routes/(shell)/+layout.svelte
+++ b/src/routes/(shell)/+layout.svelte
@@ -93,7 +93,6 @@
 					{/snippet}
 					{#snippet content()}
 						<SideBar
-							token={data.token}
 							organizations={data.organizations}
 							organizationID={data.organizationID}
 							acl={data.acl}
@@ -155,7 +154,6 @@
 	<div class="w-full h-full flex overflow-hidden bg-surface-100-900/10">
 		<div class="hidden lg:block lg:w-[320px] overflow-y-auto min-h-full">
 			<SideBar
-				token={data.token}
 				organizations={data.organizations}
 				organizationID={data.organizationID}
 				acl={data.acl}

--- a/src/routes/(shell)/+layout.ts
+++ b/src/routes/(shell)/+layout.ts
@@ -34,7 +34,7 @@ export const load: LayoutLoad = async ({ fetch, depends }) => {
 
 	// Every view will need to know the organization the user is currently viewing,
 	// we persist this across sessions.
-	const organizations = await Clients.identity(token, fetch).apiV1OrganizationsGet();
+	const organizations = await Clients.identity(fetch).apiV1OrganizationsGet();
 	if (organizations.length == 0) {
 		error(500, 'User is not a member of any organizations');
 	}
@@ -46,13 +46,12 @@ export const load: LayoutLoad = async ({ fetch, depends }) => {
 	}
 
 	// Some views will alter based on ACL data for that organization.
-	const acl = await Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDAclGet({
+	const acl = await Clients.identity(fetch).apiV1OrganizationsOrganizationIDAclGet({
 		organizationID: organizationID
 	});
 
 	return {
 		profile: profile,
-		token: token,
 		organizations: organizations,
 		organizationID: organizationID,
 		acl: acl

--- a/src/routes/(shell)/+page.ts
+++ b/src/routes/(shell)/+page.ts
@@ -5,9 +5,9 @@ import type { PageLoad } from './$types';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent }) => {
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const quotas = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDQuotasGet({
+	const quotas = Clients.identity(fetch).apiV1OrganizationsOrganizationIDQuotasGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/compute/+layout.ts
+++ b/src/routes/(shell)/compute/+layout.ts
@@ -7,13 +7,13 @@ import * as Clients from '$lib/clients';
 export const load: LayoutLoad = async ({ fetch, depends, parent }) => {
 	depends('layout:compute');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const projects = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDProjectsGet({
+	const projects = Clients.identity(fetch).apiV1OrganizationsOrganizationIDProjectsGet({
 		organizationID: organizationID
 	});
 
-	const regions = Clients.compute(token, fetch).apiV1OrganizationsOrganizationIDRegionsGet({
+	const regions = Clients.compute(fetch).apiV1OrganizationsOrganizationIDRegionsGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/compute/clusters/+layout.ts
+++ b/src/routes/(shell)/compute/clusters/+layout.ts
@@ -7,9 +7,9 @@ import * as Clients from '$lib/clients';
 export const load: LayoutLoad = async ({ fetch, depends, parent }) => {
 	depends('layout:clusters');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const clusters = Clients.compute(token, fetch).apiV1OrganizationsOrganizationIDClustersGet({
+	const clusters = Clients.compute(fetch).apiV1OrganizationsOrganizationIDClustersGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/compute/clusters/+page.svelte
+++ b/src/routes/(shell)/compute/clusters/+page.svelte
@@ -44,7 +44,7 @@
 			clusterID: resource.metadata.id
 		};
 
-		Clients.compute(data.token)
+		Clients.compute()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDClustersClusterIDDelete(parameters)
 			.then(() => invalidate('layout:clusters'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/compute/clusters/create/+page.svelte
+++ b/src/routes/(shell)/compute/clusters/create/+page.svelte
@@ -105,7 +105,7 @@
 			computeClusterWrite: resource
 		};
 
-		Clients.compute(data.token)
+		Clients.compute()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDClustersPost(parameters)
 			.then(() => window.location.assign('/compute/clusters'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/compute/clusters/create/+page.ts
+++ b/src/routes/(shell)/compute/clusters/create/+page.ts
@@ -6,23 +6,21 @@ import { error } from '@sveltejs/kit';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent, url }) => {
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
 	const regionID = url.searchParams.get('regionID');
 	if (!regionID) {
 		error(400, 'region ID not in query');
 	}
 
-	const images = Clients.kubernetes(
-		token,
-		fetch
-	).apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet({
-		organizationID: organizationID,
-		regionID: regionID
-	});
+	const images = Clients.kubernetes(fetch).apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet(
+		{
+			organizationID: organizationID,
+			regionID: regionID
+		}
+	);
 
 	const flavors = Clients.kubernetes(
-		token,
 		fetch
 	).apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet({
 		organizationID: organizationID,

--- a/src/routes/(shell)/compute/clusters/view/[id]/+page.ts
+++ b/src/routes/(shell)/compute/clusters/view/[id]/+page.ts
@@ -6,25 +6,19 @@ import { error } from '@sveltejs/kit';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent, params }) => {
-	const { token, organizationID, clusters } = await parent();
+	const { organizationID, clusters } = await parent();
 
 	const cluster = clusters.find((x) => params['id'] == x.metadata.id);
 	if (!cluster) {
 		error(400, 'unable to find cluster by ID');
 	}
 
-	const images = Clients.compute(
-		token,
-		fetch
-	).apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet({
+	const images = Clients.compute(fetch).apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet({
 		organizationID: organizationID,
 		regionID: cluster.spec.regionId
 	});
 
-	const flavors = Clients.compute(
-		token,
-		fetch
-	).apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet({
+	const flavors = Clients.compute(fetch).apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet({
 		organizationID: organizationID,
 		regionID: cluster.spec.regionId
 	});

--- a/src/routes/(shell)/identity/groups/+layout.ts
+++ b/src/routes/(shell)/identity/groups/+layout.ts
@@ -7,9 +7,9 @@ import * as Clients from '$lib/clients';
 export const load: LayoutLoad = async ({ fetch, depends, parent }) => {
 	depends('layout:groups');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const groups = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDGroupsGet({
+	const groups = Clients.identity(fetch).apiV1OrganizationsOrganizationIDGroupsGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/identity/groups/+page.svelte
+++ b/src/routes/(shell)/identity/groups/+page.svelte
@@ -36,7 +36,7 @@
 			groupid: id
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDGroupsGroupidDelete(parameters)
 			.then(() => invalidate('page:groups'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/groups/create/+page.svelte
+++ b/src/routes/(shell)/identity/groups/create/+page.svelte
@@ -43,7 +43,7 @@
 			groupWrite: resource
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDGroupsPost(parameters)
 			.then(() => window.location.assign('/identity/groups'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/groups/create/+page.ts
+++ b/src/routes/(shell)/identity/groups/create/+page.ts
@@ -5,18 +5,17 @@ import type { PageLoad } from './$types';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent }) => {
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const roles = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDRolesGet({
+	const roles = Clients.identity(fetch).apiV1OrganizationsOrganizationIDRolesGet({
 		organizationID: organizationID
 	});
 
-	const users = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDUsersGet({
+	const users = Clients.identity(fetch).apiV1OrganizationsOrganizationIDUsersGet({
 		organizationID: organizationID
 	});
 
 	const serviceAccounts = Clients.identity(
-		token,
 		fetch
 	).apiV1OrganizationsOrganizationIDServiceaccountsGet({
 		organizationID: organizationID

--- a/src/routes/(shell)/identity/groups/view/[id]/+page.svelte
+++ b/src/routes/(shell)/identity/groups/view/[id]/+page.svelte
@@ -40,7 +40,7 @@
 			groupWrite: group
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDGroupsGroupidPut(parameters)
 			.then(() => window.location.assign('/identity/groups'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/groups/view/[id]/+page.ts
+++ b/src/routes/(shell)/identity/groups/view/[id]/+page.ts
@@ -6,23 +6,22 @@ import { error } from '@sveltejs/kit';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent, params }) => {
-	const { token, organizationID, groups } = await parent();
+	const { organizationID, groups } = await parent();
 
 	const group = groups.find((x) => x.metadata.id == params['id']);
 	if (!group) {
 		error(404, 'group not found');
 	}
 
-	const roles = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDRolesGet({
+	const roles = Clients.identity(fetch).apiV1OrganizationsOrganizationIDRolesGet({
 		organizationID: organizationID
 	});
 
-	const users = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDUsersGet({
+	const users = Clients.identity(fetch).apiV1OrganizationsOrganizationIDUsersGet({
 		organizationID: organizationID
 	});
 
 	const serviceAccounts = Clients.identity(
-		token,
 		fetch
 	).apiV1OrganizationsOrganizationIDServiceaccountsGet({
 		organizationID: organizationID

--- a/src/routes/(shell)/identity/oauth2providers/+layout.ts
+++ b/src/routes/(shell)/identity/oauth2providers/+layout.ts
@@ -7,10 +7,9 @@ import * as Clients from '$lib/clients';
 export const load: LayoutLoad = async ({ fetch, depends, parent }) => {
 	depends('layout:oauth2providers');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
 	const oauth2providers = Clients.identity(
-		token,
 		fetch
 	).apiV1OrganizationsOrganizationIDOauth2providersGet({
 		organizationID: organizationID

--- a/src/routes/(shell)/identity/oauth2providers/+page.svelte
+++ b/src/routes/(shell)/identity/oauth2providers/+page.svelte
@@ -36,7 +36,7 @@
 			providerID: id
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDOauth2providersProviderIDDelete(parameters)
 			.then(() => invalidate('layout:oauth2providers'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/oauth2providers/create/+page.svelte
+++ b/src/routes/(shell)/identity/oauth2providers/create/+page.svelte
@@ -47,7 +47,7 @@
 			oauth2ProviderWrite: resource
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDOauth2providersPost(parameters)
 			.then(() => window.location.assign('/identity/oauth2providers'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/organizations/+page.svelte
+++ b/src/routes/(shell)/identity/organizations/+page.svelte
@@ -35,7 +35,7 @@
 			organizationWrite: organization
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDPut(parameters)
 			.catch((e: Error) => Clients.error(e));
 	}

--- a/src/routes/(shell)/identity/organizations/+page.ts
+++ b/src/routes/(shell)/identity/organizations/+page.ts
@@ -6,17 +6,16 @@ import { error } from '@sveltejs/kit';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent }) => {
-	const { token, organizationID, organizations } = await parent();
+	const { organizationID, organizations } = await parent();
 
 	const organization = organizations.find((x) => x.metadata.id == organizationID);
 	if (!organization) {
 		error(404, 'organization not found');
 	}
 
-	const oauth2providers = Clients.identity(token, fetch).apiV1Oauth2providersGet();
+	const oauth2providers = Clients.identity(fetch).apiV1Oauth2providersGet();
 
 	const orgOauth2providers = Clients.identity(
-		token,
 		fetch
 	).apiV1OrganizationsOrganizationIDOauth2providersGet({ organizationID: organizationID });
 

--- a/src/routes/(shell)/identity/projects/+layout.ts
+++ b/src/routes/(shell)/identity/projects/+layout.ts
@@ -7,9 +7,9 @@ import * as Clients from '$lib/clients';
 export const load: LayoutLoad = async ({ fetch, depends, parent }) => {
 	depends('layout:projects');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const projects = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDProjectsGet({
+	const projects = Clients.identity(fetch).apiV1OrganizationsOrganizationIDProjectsGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/identity/projects/+page.svelte
+++ b/src/routes/(shell)/identity/projects/+page.svelte
@@ -36,7 +36,7 @@
 			projectID: id
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDDelete(parameters)
 			.then(() => invalidate('layout:projects'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/projects/create/+page.svelte
+++ b/src/routes/(shell)/identity/projects/create/+page.svelte
@@ -43,7 +43,7 @@
 			projectWrite: resource
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDProjectsPost(parameters)
 			.then(() => window.location.assign('/identity/projects'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/projects/create/+page.ts
+++ b/src/routes/(shell)/identity/projects/create/+page.ts
@@ -5,9 +5,9 @@ import type { PageLoad } from './$types';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent }) => {
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const groups = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDGroupsGet({
+	const groups = Clients.identity(fetch).apiV1OrganizationsOrganizationIDGroupsGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/identity/projects/view/[id]/+page.svelte
+++ b/src/routes/(shell)/identity/projects/view/[id]/+page.svelte
@@ -42,7 +42,7 @@
 			projectWrite: project
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDPut(parameters)
 			.then(() => window.location.assign('/identity/projects'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/projects/view/[id]/+page.ts
+++ b/src/routes/(shell)/identity/projects/view/[id]/+page.ts
@@ -6,14 +6,14 @@ import { error } from '@sveltejs/kit';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent, params }) => {
-	const { token, organizationID, projects } = await parent();
+	const { organizationID, projects } = await parent();
 
 	const project = projects.find((x) => x.metadata.id == params['id']);
 	if (!project) {
 		error(404, 'project not found');
 	}
 
-	const groups = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDGroupsGet({
+	const groups = Clients.identity(fetch).apiV1OrganizationsOrganizationIDGroupsGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/identity/quotas/+page.svelte
+++ b/src/routes/(shell)/identity/quotas/+page.svelte
@@ -28,7 +28,7 @@
 			quotasWrite: quotas
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDQuotasPut(parameters)
 			.catch((e: Error) => Clients.error(e));
 	}

--- a/src/routes/(shell)/identity/quotas/+page.ts
+++ b/src/routes/(shell)/identity/quotas/+page.ts
@@ -5,9 +5,9 @@ import type { PageLoad } from './$types';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent }) => {
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const quotas = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDQuotasGet({
+	const quotas = Clients.identity(fetch).apiV1OrganizationsOrganizationIDQuotasGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/identity/serviceaccounts/+layout.ts
+++ b/src/routes/(shell)/identity/serviceaccounts/+layout.ts
@@ -7,10 +7,9 @@ import * as Clients from '$lib/clients';
 export const load: LayoutLoad = async ({ fetch, depends, parent }) => {
 	depends('layout:serviceaccounts');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
 	const serviceAccounts = Clients.identity(
-		token,
 		fetch
 	).apiV1OrganizationsOrganizationIDServiceaccountsGet({
 		organizationID: organizationID

--- a/src/routes/(shell)/identity/serviceaccounts/+page.svelte
+++ b/src/routes/(shell)/identity/serviceaccounts/+page.svelte
@@ -37,7 +37,7 @@
 			serviceAccountID: id
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDServiceaccountsServiceAccountIDDelete(parameters)
 			.then(() => invalidate('layout:serviceaccounts'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/serviceaccounts/create/+page.svelte
+++ b/src/routes/(shell)/identity/serviceaccounts/create/+page.svelte
@@ -45,7 +45,7 @@
 			serviceAccountWrite: resource
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDServiceaccountsPost(parameters)
 			.then((v: Identity.ServiceAccountCreate) => (serviceAccount = v))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/serviceaccounts/create/+page.ts
+++ b/src/routes/(shell)/identity/serviceaccounts/create/+page.ts
@@ -5,9 +5,9 @@ import type { PageLoad } from './$types';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent }) => {
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const groups = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDGroupsGet({
+	const groups = Clients.identity(fetch).apiV1OrganizationsOrganizationIDGroupsGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/identity/serviceaccounts/view/[id]/+page.svelte
+++ b/src/routes/(shell)/identity/serviceaccounts/view/[id]/+page.svelte
@@ -35,7 +35,7 @@
 			serviceAccountWrite: serviceAccount
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDServiceaccountsServiceAccountIDPut(parameters)
 			.then(() => window.location.assign('/identity/serviceaccounts'))
 			.catch((e: Error) => Clients.error(e));
@@ -49,7 +49,7 @@
 			serviceAccountID: $page.params.id
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDServiceaccountsServiceAccountIDRotatePost(parameters)
 			.then((v: Identity.ServiceAccountCreate) => (newServiceAccount = v))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/serviceaccounts/view/[id]/+page.ts
+++ b/src/routes/(shell)/identity/serviceaccounts/view/[id]/+page.ts
@@ -6,14 +6,14 @@ import { error } from '@sveltejs/kit';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent, params }) => {
-	const { token, organizationID, serviceAccounts } = await parent();
+	const { organizationID, serviceAccounts } = await parent();
 
 	const serviceAccount = serviceAccounts.find((x) => x.metadata.id == params['id']);
 	if (!serviceAccount) {
 		error(404, 'service account not found');
 	}
 
-	const groups = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDGroupsGet({
+	const groups = Clients.identity(fetch).apiV1OrganizationsOrganizationIDGroupsGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/identity/users/+layout.ts
+++ b/src/routes/(shell)/identity/users/+layout.ts
@@ -7,9 +7,9 @@ import * as Clients from '$lib/clients';
 export const load: LayoutLoad = async ({ fetch, depends, parent }) => {
 	depends('layout:users');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const users = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDUsersGet({
+	const users = Clients.identity(fetch).apiV1OrganizationsOrganizationIDUsersGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/identity/users/+page.svelte
+++ b/src/routes/(shell)/identity/users/+page.svelte
@@ -40,7 +40,7 @@
 			userID: id
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDUsersUserIDDelete(parameters)
 			.then(() => invalidate('layout:users'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/users/create/+page.svelte
+++ b/src/routes/(shell)/identity/users/create/+page.svelte
@@ -41,7 +41,7 @@
 			userWrite: resource
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDUsersPost(parameters)
 			.then(() => window.location.assign('/identity/users'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/users/create/+page.ts
+++ b/src/routes/(shell)/identity/users/create/+page.ts
@@ -5,9 +5,9 @@ import type { PageLoad } from './$types';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent }) => {
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const groups = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDGroupsGet({
+	const groups = Clients.identity(fetch).apiV1OrganizationsOrganizationIDGroupsGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/identity/users/view/[id]/+page.svelte
+++ b/src/routes/(shell)/identity/users/view/[id]/+page.svelte
@@ -34,7 +34,7 @@
 			userWrite: user
 		};
 
-		Clients.identity(data.token)
+		Clients.identity()
 			.apiV1OrganizationsOrganizationIDUsersUserIDPut(parameters)
 			.then(() => window.location.assign('/identity/users'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/identity/users/view/[id]/+page.ts
+++ b/src/routes/(shell)/identity/users/view/[id]/+page.ts
@@ -6,14 +6,14 @@ import { error } from '@sveltejs/kit';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent, params }) => {
-	const { token, organizationID, users } = await parent();
+	const { organizationID, users } = await parent();
 
 	const user = users.find((x) => x.metadata.id == params['id']);
 	if (!user) {
 		error(404, 'user not found');
 	}
 
-	const groups = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDGroupsGet({
+	const groups = Clients.identity(fetch).apiV1OrganizationsOrganizationIDGroupsGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/kubernetes/+layout.ts
+++ b/src/routes/(shell)/kubernetes/+layout.ts
@@ -7,9 +7,9 @@ import * as Clients from '$lib/clients';
 export const load: LayoutLoad = async ({ fetch, depends, parent }) => {
 	depends('layout:kubernetes');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const projects = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDProjectsGet({
+	const projects = Clients.identity(fetch).apiV1OrganizationsOrganizationIDProjectsGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/kubernetes/clustermanagers/+layout.ts
+++ b/src/routes/(shell)/kubernetes/clustermanagers/+layout.ts
@@ -7,10 +7,9 @@ import * as Clients from '$lib/clients';
 export const load: LayoutLoad = async ({ fetch, depends, parent }) => {
 	depends('layout:clustermanagers');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
 	const clustermanagers = Clients.kubernetes(
-		token,
 		fetch
 	).apiV1OrganizationsOrganizationIDClustermanagersGet({
 		organizationID: organizationID

--- a/src/routes/(shell)/kubernetes/clustermanagers/+page.svelte
+++ b/src/routes/(shell)/kubernetes/clustermanagers/+page.svelte
@@ -37,7 +37,7 @@
 			clusterManagerID: resource.metadata.id
 		};
 
-		Clients.kubernetes(data.token)
+		Clients.kubernetes()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDClustermanagersClusterManagerIDDelete(
 				parameters
 			)

--- a/src/routes/(shell)/kubernetes/clusters/+layout.ts
+++ b/src/routes/(shell)/kubernetes/clusters/+layout.ts
@@ -8,13 +8,13 @@ import * as Kubernetes from '$lib/openapi/kubernetes';
 export const load: LayoutLoad = async ({ fetch, depends, parent }) => {
 	depends('layout:clusters');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const clusters = Clients.kubernetes(token, fetch).apiV1OrganizationsOrganizationIDClustersGet({
+	const clusters = Clients.kubernetes(fetch).apiV1OrganizationsOrganizationIDClustersGet({
 		organizationID: organizationID
 	});
 
-	const regions = Clients.kubernetes(token, fetch).apiV1OrganizationsOrganizationIDRegionsGet({
+	const regions = Clients.kubernetes(fetch).apiV1OrganizationsOrganizationIDRegionsGet({
 		organizationID: organizationID,
 		regionType: Kubernetes.RegionTypeParameter.Physical
 	});

--- a/src/routes/(shell)/kubernetes/clusters/+page.svelte
+++ b/src/routes/(shell)/kubernetes/clusters/+page.svelte
@@ -44,7 +44,7 @@
 			clusterID: resource.metadata.id
 		};
 
-		Clients.kubernetes(data.token)
+		Clients.kubernetes()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDClustersClusterIDDelete(parameters)
 			.then(() => invalidate('layout:clusters'))
 			.catch((e: Error) => Clients.error(e));
@@ -57,7 +57,7 @@
 			clusterID: resource.metadata.id
 		};
 
-		Clients.kubernetes(data.token)
+		Clients.kubernetes()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDClustersClusterIDKubeconfigGetRaw(
 				parameters
 			)

--- a/src/routes/(shell)/kubernetes/clusters/create/+page.svelte
+++ b/src/routes/(shell)/kubernetes/clusters/create/+page.svelte
@@ -199,7 +199,7 @@
 			kubernetesClusterWrite: resource
 		};
 
-		Clients.kubernetes(data.token)
+		Clients.kubernetes()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDClustersPost(parameters)
 			.then(() => window.location.assign('/kubernetes/clusters'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/kubernetes/clusters/create/+page.ts
+++ b/src/routes/(shell)/kubernetes/clusters/create/+page.ts
@@ -6,7 +6,7 @@ import { error } from '@sveltejs/kit';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent, url }) => {
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
 	const regionID = url.searchParams.get('regionID');
 	if (!regionID) {
@@ -18,16 +18,14 @@ export const load: PageLoad = async ({ fetch, parent, url }) => {
 		error(400, 'project ID not in query');
 	}
 
-	const images = Clients.kubernetes(
-		token,
-		fetch
-	).apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet({
-		organizationID: organizationID,
-		regionID: regionID
-	});
+	const images = Clients.kubernetes(fetch).apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet(
+		{
+			organizationID: organizationID,
+			regionID: regionID
+		}
+	);
 
 	const flavors = Clients.kubernetes(
-		token,
 		fetch
 	).apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet({
 		organizationID: organizationID,

--- a/src/routes/(shell)/kubernetes/clusters/view/[id]/+page.svelte
+++ b/src/routes/(shell)/kubernetes/clusters/view/[id]/+page.svelte
@@ -250,7 +250,7 @@
 			kubernetesClusterWrite: cluster
 		};
 
-		Clients.kubernetes(data.token)
+		Clients.kubernetes()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDClustersClusterIDPut(parameters)
 			.then(() => window.location.assign('/kubernetes/clusters'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/kubernetes/clusters/view/[id]/+page.ts
+++ b/src/routes/(shell)/kubernetes/clusters/view/[id]/+page.ts
@@ -6,7 +6,7 @@ import { error } from '@sveltejs/kit';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent, params }) => {
-	const { token, organizationID, clusters } = await parent();
+	const { organizationID, clusters } = await parent();
 
 	const cluster = clusters.find((x) => params['id'] == x.metadata.id);
 	if (!cluster) {
@@ -14,22 +14,19 @@ export const load: PageLoad = async ({ fetch, parent, params }) => {
 	}
 
 	const clustermanagers = Clients.kubernetes(
-		token,
 		fetch
 	).apiV1OrganizationsOrganizationIDClustermanagersGet({
 		organizationID: organizationID
 	});
 
-	const images = Clients.kubernetes(
-		token,
-		fetch
-	).apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet({
-		organizationID: organizationID,
-		regionID: cluster.spec.regionId
-	});
+	const images = Clients.kubernetes(fetch).apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet(
+		{
+			organizationID: organizationID,
+			regionID: cluster.spec.regionId
+		}
+	);
 
 	const flavors = Clients.kubernetes(
-		token,
 		fetch
 	).apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet({
 		organizationID: organizationID,

--- a/src/routes/(shell)/kubernetes/virtualclusters/+layout.ts
+++ b/src/routes/(shell)/kubernetes/virtualclusters/+layout.ts
@@ -8,16 +8,13 @@ import * as Kubernetes from '$lib/openapi/kubernetes';
 export const load: LayoutLoad = async ({ fetch, depends, parent }) => {
 	depends('layout:virtualclusters');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const clusters = Clients.kubernetes(
-		token,
-		fetch
-	).apiV1OrganizationsOrganizationIDVirtualclustersGet({
+	const clusters = Clients.kubernetes(fetch).apiV1OrganizationsOrganizationIDVirtualclustersGet({
 		organizationID: organizationID
 	});
 
-	const regions = Clients.kubernetes(token, fetch).apiV1OrganizationsOrganizationIDRegionsGet({
+	const regions = Clients.kubernetes(fetch).apiV1OrganizationsOrganizationIDRegionsGet({
 		organizationID: organizationID,
 		regionType: Kubernetes.RegionTypeParameter.Virtual
 	});

--- a/src/routes/(shell)/kubernetes/virtualclusters/+page.svelte
+++ b/src/routes/(shell)/kubernetes/virtualclusters/+page.svelte
@@ -44,7 +44,7 @@
 			clusterID: resource.metadata.id
 		};
 
-		Clients.kubernetes(data.token)
+		Clients.kubernetes()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDVirtualclustersClusterIDDelete(parameters)
 			.then(() => invalidate('layout:clusters'))
 			.catch((e: Error) => Clients.error(e));
@@ -57,7 +57,7 @@
 			clusterID: resource.metadata.id
 		};
 
-		Clients.kubernetes(data.token)
+		Clients.kubernetes()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDVirtualclustersClusterIDKubeconfigGetRaw(
 				parameters
 			)

--- a/src/routes/(shell)/kubernetes/virtualclusters/create/+page.svelte
+++ b/src/routes/(shell)/kubernetes/virtualclusters/create/+page.svelte
@@ -85,7 +85,7 @@
 			virtualKubernetesClusterWrite: resource
 		};
 
-		Clients.kubernetes(data.token)
+		Clients.kubernetes()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDVirtualclustersPost(parameters)
 			.then(() => window.location.assign('/kubernetes/virtualclusters'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/kubernetes/virtualclusters/create/+page.ts
+++ b/src/routes/(shell)/kubernetes/virtualclusters/create/+page.ts
@@ -6,7 +6,7 @@ import { error } from '@sveltejs/kit';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent, url }) => {
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
 	const regionID = url.searchParams.get('regionID');
 	if (!regionID) {
@@ -19,7 +19,6 @@ export const load: PageLoad = async ({ fetch, parent, url }) => {
 	}
 
 	const flavors = Clients.kubernetes(
-		token,
 		fetch
 	).apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet({
 		organizationID: organizationID,

--- a/src/routes/(shell)/kubernetes/virtualclusters/view/[id]/+page.svelte
+++ b/src/routes/(shell)/kubernetes/virtualclusters/view/[id]/+page.svelte
@@ -126,7 +126,7 @@
 			virtualKubernetesClusterWrite: cluster
 		};
 
-		Clients.kubernetes(data.token)
+		Clients.kubernetes()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDVirtualclustersClusterIDPut(parameters)
 			.then(() => window.location.assign('/kubernetes/virtualclusters'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/kubernetes/virtualclusters/view/[id]/+page.ts
+++ b/src/routes/(shell)/kubernetes/virtualclusters/view/[id]/+page.ts
@@ -6,7 +6,7 @@ import { error } from '@sveltejs/kit';
 import * as Clients from '$lib/clients';
 
 export const load: PageLoad = async ({ fetch, parent, params }) => {
-	const { token, organizationID, clusters } = await parent();
+	const { organizationID, clusters } = await parent();
 
 	const cluster = clusters.find((x) => params['id'] == x.metadata.id);
 	if (!cluster) {
@@ -14,7 +14,6 @@ export const load: PageLoad = async ({ fetch, parent, params }) => {
 	}
 
 	const flavors = Clients.kubernetes(
-		token,
 		fetch
 	).apiV1OrganizationsOrganizationIDRegionsRegionIDFlavorsGet({
 		organizationID: organizationID,

--- a/src/routes/(shell)/regions/+layout.ts
+++ b/src/routes/(shell)/regions/+layout.ts
@@ -7,13 +7,13 @@ import * as Clients from '$lib/clients';
 export const load: LayoutLoad = async ({ fetch, depends, parent }) => {
 	depends('layout:region');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const projects = Clients.identity(token, fetch).apiV1OrganizationsOrganizationIDProjectsGet({
+	const projects = Clients.identity(fetch).apiV1OrganizationsOrganizationIDProjectsGet({
 		organizationID: organizationID
 	});
 
-	const regions = Clients.region(token, fetch).apiV1OrganizationsOrganizationIDRegionsGet({
+	const regions = Clients.region(fetch).apiV1OrganizationsOrganizationIDRegionsGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/regions/identities/+layout.ts
+++ b/src/routes/(shell)/regions/identities/+layout.ts
@@ -7,9 +7,9 @@ import * as Clients from '$lib/clients';
 export const load: LayoutLoad = async ({ depends, fetch, parent }) => {
 	depends('layout:identities');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const identities = Clients.region(token, fetch).apiV1OrganizationsOrganizationIDIdentitiesGet({
+	const identities = Clients.region(fetch).apiV1OrganizationsOrganizationIDIdentitiesGet({
 		organizationID: organizationID
 	});
 

--- a/src/routes/(shell)/regions/identities/+page.svelte
+++ b/src/routes/(shell)/regions/identities/+page.svelte
@@ -39,7 +39,7 @@
 			identityID: resource.metadata.id
 		};
 
-		Clients.region(data.token)
+		Clients.region()
 			.apiV1OrganizationsOrganizationIDProjectsProjectIDIdentitiesIdentityIDDelete(parameters)
 			.then(() => invalidate('layout:identities'))
 			.catch((e: Error) => Clients.error(e));

--- a/src/routes/(shell)/regions/networks/+layout.ts
+++ b/src/routes/(shell)/regions/networks/+layout.ts
@@ -7,9 +7,9 @@ import * as Clients from '$lib/clients';
 export const load: LayoutLoad = async ({ fetch, depends, parent }) => {
 	depends('layout:networks');
 
-	const { token, organizationID } = await parent();
+	const { organizationID } = await parent();
 
-	const networks = Clients.region(token, fetch).apiV1OrganizationsOrganizationIDNetworksGet({
+	const networks = Clients.region(fetch).apiV1OrganizationsOrganizationIDNetworksGet({
 		organizationID: organizationID
 	});
 


### PR DESCRIPTION
There is a race when multiple API calls happen concurrently, both trying to refresh to the token at the same time, when the refresh token can only be used once.  Add some synchronization to prevent this so the leader does the refresh and followers wait.  This also cleans up the client interfaces by directly grabbing the tokens from session storage rather than propagating them everywhere.

Fixes #209