### PR TITLE
Show percentage not value in dashboard

### DIFF
--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: v0.3.16-rc1
-appVersion: v0.3.16-rc1
+version: v0.3.16-rc2
+appVersion: v0.3.16-rc2
 
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 

--- a/src/routes/(shell)/+page.svelte
+++ b/src/routes/(shell)/+page.svelte
@@ -28,9 +28,9 @@
 						<div class="italic text-sm text-surface-700-300">{quota.description}</div>
 					</div>
 					<div class="flex items-center gap-4">
+						<!-- the default is to treat the value as a pencentage -->
 						<ProgressRing
-							value={quota.used}
-							max={quota.quantity}
+							value={quota.quantity <= 0 ? 0 : (quota.used / quota.quantity) * 100}
 							showLabel
 							trackStroke="stroke-primary-500/20"
 							strokeWidth="0.75rem"


### PR DESCRIPTION
https://www.skeleton.dev/docs/components/progress-ring/svelte#api-reference suggests that the ProgressRing will calculate the proportion it displays inside the ring, given the `value` and `max`; however, what it _does_ is show the value, with a percentage sign.

To make sure we're showing a percentage, actually calculate it as a percentage and let the `max` default to `100` (and format to `percentage` as before).
