### PR TITLE
Required Lists in Universal Load Functions

### DIFF
--- a/src/lib/loadutil.ts
+++ b/src/lib/loadutil.ts
@@ -1,0 +1,17 @@
+import { error } from '@sveltejs/kit';
+
+interface Lengthable {
+	length: number;
+}
+
+export async function assertNonEmptyList<Type extends Lengthable>(
+	lister: Promise<Type>
+): Promise<Type> {
+	const list = await lister;
+
+	if (list.length == 0) {
+		error(500, `list type is unexpectedly empty, ensure your deployment is configured correctly`);
+	}
+
+	return list;
+}

--- a/src/routes/(shell)/compute/clusters/create/+page.ts
+++ b/src/routes/(shell)/compute/clusters/create/+page.ts
@@ -4,6 +4,7 @@ import type { PageLoad } from './$types';
 import { error } from '@sveltejs/kit';
 
 import * as Clients from '$lib/clients';
+import { assertNonEmptyList } from '$lib/loadutil';
 
 export const load: PageLoad = async ({ fetch, parent, url }) => {
 	const { organizationID } = await parent();
@@ -28,7 +29,7 @@ export const load: PageLoad = async ({ fetch, parent, url }) => {
 	});
 
 	return {
-		images: await images,
-		flavors: await flavors
+		images: await assertNonEmptyList(images),
+		flavors: await assertNonEmptyList(flavors)
 	};
 };

--- a/src/routes/(shell)/kubernetes/clusters/create/+page.ts
+++ b/src/routes/(shell)/kubernetes/clusters/create/+page.ts
@@ -4,6 +4,7 @@ import type { PageLoad } from './$types';
 import { error } from '@sveltejs/kit';
 
 import * as Clients from '$lib/clients';
+import { assertNonEmptyList } from '$lib/loadutil';
 
 export const load: PageLoad = async ({ fetch, parent, url }) => {
 	const { organizationID } = await parent();
@@ -35,7 +36,7 @@ export const load: PageLoad = async ({ fetch, parent, url }) => {
 	return {
 		projectID: projectID,
 		regionID: regionID,
-		images: await images,
-		flavors: await flavors
+		images: await assertNonEmptyList(images),
+		flavors: await assertNonEmptyList(flavors)
 	};
 };

--- a/src/routes/(shell)/kubernetes/virtualclusters/create/+page.ts
+++ b/src/routes/(shell)/kubernetes/virtualclusters/create/+page.ts
@@ -4,6 +4,7 @@ import type { PageLoad } from './$types';
 import { error } from '@sveltejs/kit';
 
 import * as Clients from '$lib/clients';
+import { assertNonEmptyList } from '$lib/loadutil';
 
 export const load: PageLoad = async ({ fetch, parent, url }) => {
 	const { organizationID } = await parent();
@@ -28,6 +29,6 @@ export const load: PageLoad = async ({ fetch, parent, url }) => {
 	return {
 		projectID: projectID,
 		regionID: regionID,
-		flavors: await flavors
+		flavors: await assertNonEmptyList(flavors)
 	};
 };


### PR DESCRIPTION
Some things require lists returned from universal load functions to be non-empty, primarily flavors and images.  Add a wrapper promise that raises an error if the assertion fails.

Fixes #213