### PR TITLE
Fix Bad Slug Lookups

### DIFF
--- a/src/routes/(shell)/compute/clusters/edit/[id]/+page.ts
+++ b/src/routes/(shell)/compute/clusters/edit/[id]/+page.ts
@@ -1,17 +1,17 @@
 export const ssr = false;
 
 import type { PageLoad } from './$types';
-import { error } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 
 import * as Clients from '$lib/clients';
 import { assertNonEmptyList } from '$lib/loadutil';
 
-export const load: PageLoad = async ({ fetch, parent, params }) => {
+export const load: PageLoad = async ({ fetch, parent, params, url }) => {
 	const { organizationID, clusters } = await parent();
 
 	const cluster = clusters.find((x) => params['id'] == x.metadata.id);
 	if (!cluster) {
-		error(404, 'compute cluster not found');
+		redirect(307, url.pathname.split('/').slice(0, -2).join('/'));
 	}
 
 	// Find all clusters in this project that aren't the one we care about and

--- a/src/routes/(shell)/compute/clusters/view/[id]/+page.ts
+++ b/src/routes/(shell)/compute/clusters/view/[id]/+page.ts
@@ -1,16 +1,16 @@
 export const ssr = false;
 
 import type { PageLoad } from './$types';
-import { error } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 
 import * as Clients from '$lib/clients';
 
-export const load: PageLoad = async ({ fetch, parent, params }) => {
+export const load: PageLoad = async ({ fetch, parent, params, url }) => {
 	const { organizationID, clusters } = await parent();
 
 	const cluster = clusters.find((x) => params['id'] == x.metadata.id);
 	if (!cluster) {
-		error(400, 'unable to find cluster by ID');
+		redirect(307, url.pathname.split('/').slice(0, -2).join('/'));
 	}
 
 	const images = Clients.compute(fetch).apiV1OrganizationsOrganizationIDRegionsRegionIDImagesGet({

--- a/src/routes/(shell)/identity/groups/view/[id]/+page.ts
+++ b/src/routes/(shell)/identity/groups/view/[id]/+page.ts
@@ -1,16 +1,16 @@
 export const ssr = false;
 
 import type { PageLoad } from './$types';
-import { error } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 
 import * as Clients from '$lib/clients';
 
-export const load: PageLoad = async ({ fetch, parent, params }) => {
+export const load: PageLoad = async ({ fetch, parent, params, url }) => {
 	const { organizationID, groups } = await parent();
 
 	const group = groups.find((x) => x.metadata.id == params['id']);
 	if (!group) {
-		error(404, 'group not found');
+		redirect(307, url.pathname.split('/').slice(0, -2).join('/'));
 	}
 
 	const roles = Clients.identity(fetch).apiV1OrganizationsOrganizationIDRolesGet({

--- a/src/routes/(shell)/identity/projects/view/[id]/+page.ts
+++ b/src/routes/(shell)/identity/projects/view/[id]/+page.ts
@@ -1,16 +1,16 @@
 export const ssr = false;
 
 import type { PageLoad } from './$types';
-import { error } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 
 import * as Clients from '$lib/clients';
 
-export const load: PageLoad = async ({ fetch, parent, params }) => {
+export const load: PageLoad = async ({ fetch, parent, params, url }) => {
 	const { organizationID, projects } = await parent();
 
 	const project = projects.find((x) => x.metadata.id == params['id']);
 	if (!project) {
-		error(404, 'project not found');
+		redirect(307, url.pathname.split('/').slice(0, -2).join('/'));
 	}
 
 	const groups = Clients.identity(fetch).apiV1OrganizationsOrganizationIDGroupsGet({

--- a/src/routes/(shell)/identity/serviceaccounts/view/[id]/+page.ts
+++ b/src/routes/(shell)/identity/serviceaccounts/view/[id]/+page.ts
@@ -1,16 +1,16 @@
 export const ssr = false;
 
 import type { PageLoad } from './$types';
-import { error } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 
 import * as Clients from '$lib/clients';
 
-export const load: PageLoad = async ({ fetch, parent, params }) => {
+export const load: PageLoad = async ({ fetch, parent, params, url }) => {
 	const { organizationID, serviceAccounts } = await parent();
 
 	const serviceAccount = serviceAccounts.find((x) => x.metadata.id == params['id']);
 	if (!serviceAccount) {
-		error(404, 'service account not found');
+		redirect(307, url.pathname.split('/').slice(0, -2).join('/'));
 	}
 
 	const groups = Clients.identity(fetch).apiV1OrganizationsOrganizationIDGroupsGet({

--- a/src/routes/(shell)/identity/users/view/[id]/+page.ts
+++ b/src/routes/(shell)/identity/users/view/[id]/+page.ts
@@ -1,16 +1,16 @@
 export const ssr = false;
 
 import type { PageLoad } from './$types';
-import { error } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 
 import * as Clients from '$lib/clients';
 
-export const load: PageLoad = async ({ fetch, parent, params }) => {
+export const load: PageLoad = async ({ fetch, parent, params, url }) => {
 	const { organizationID, users } = await parent();
 
 	const user = users.find((x) => x.metadata.id == params['id']);
 	if (!user) {
-		error(404, 'user not found');
+		redirect(307, url.pathname.split('/').slice(0, -2).join('/'));
 	}
 
 	const groups = Clients.identity(fetch).apiV1OrganizationsOrganizationIDGroupsGet({

--- a/src/routes/(shell)/kubernetes/clusters/view/[id]/+page.ts
+++ b/src/routes/(shell)/kubernetes/clusters/view/[id]/+page.ts
@@ -1,16 +1,16 @@
 export const ssr = false;
 
 import type { PageLoad } from './$types';
-import { error } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 
 import * as Clients from '$lib/clients';
 
-export const load: PageLoad = async ({ fetch, parent, params }) => {
+export const load: PageLoad = async ({ fetch, parent, params, url }) => {
 	const { organizationID, clusters } = await parent();
 
 	const cluster = clusters.find((x) => params['id'] == x.metadata.id);
 	if (!cluster) {
-		error(404, 'kubernetes cluster not found');
+		redirect(307, url.pathname.split('/').slice(0, -2).join('/'));
 	}
 
 	// Find all clusters in this project that aren't the one we care about and

--- a/src/routes/(shell)/kubernetes/virtualclusters/view/[id]/+page.ts
+++ b/src/routes/(shell)/kubernetes/virtualclusters/view/[id]/+page.ts
@@ -1,16 +1,16 @@
 export const ssr = false;
 
 import type { PageLoad } from './$types';
-import { error } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 
 import * as Clients from '$lib/clients';
 
-export const load: PageLoad = async ({ fetch, parent, params }) => {
+export const load: PageLoad = async ({ fetch, parent, params, url }) => {
 	const { organizationID, clusters } = await parent();
 
 	const cluster = clusters.find((x) => params['id'] == x.metadata.id);
 	if (!cluster) {
-		error(404, 'kubernetes cluster not found');
+		redirect(307, url.pathname.split('/').slice(0, -2).join('/'));
 	}
 
 	const flavors = Clients.kubernetes(


### PR DESCRIPTION
If you are on a path with a slug e.g. a resource view, and you context switch to a new organization, that slug will no longer be valid.  At present we just raise an error.  What this does is redirects to the parent page, so we can see all resources for that organization.