### PR TITLE
fix(groups): strip subjects from group update request

### DIFF
--- a/src/routes/(shell)/identity/groups/view/[id]/+page.svelte
+++ b/src/routes/(shell)/identity/groups/view/[id]/+page.svelte
@@ -38,7 +38,10 @@
 		const parameters = {
 			organizationID: data.organizationID,
 			groupid: group.metadata.id,
-			groupWrite: group
+			groupWrite: {
+				...group,
+				spec: { ...group.spec, subjects: undefined }
+			}
 		};
 
 		Clients.identity()


### PR DESCRIPTION
The group read response populates both subjects and userIDs, but the API rejects requests that supply both fields. Strip subjects before submitting the update since the UI operates exclusively with userIDs.