### PR TITLE
Enforce architecture matching between flavors and images

### DIFF
--- a/src/lib/Flavor.svelte
+++ b/src/lib/Flavor.svelte
@@ -11,7 +11,7 @@
 {#if flavor}
 	<span class="flavor">
 		<span class="k">CPU</span>
-		{flavor.spec.cpus} core
+		{flavor.spec.cpus}× {flavor.spec.architecture}
 		<span class="sep">·</span>
 		<span class="k">RAM</span>
 		{flavor.spec.memory} GiB
@@ -21,8 +21,8 @@
 		{#if flavor.spec.gpu}
 			<span class="sep">·</span>
 			<span class="k">GPU</span>
-			{flavor.spec.gpu.physicalCount}× {flavor.spec.gpu.model} · {flavor.spec.gpu.logicalCount} logical
-			· {flavor.spec.gpu.memory} GiB
+			{flavor.spec.gpu.physicalCount}× {flavor.spec.gpu.model} ({flavor.spec.gpu.logicalCount} logical
+			· {flavor.spec.gpu.memory} GiB)
 		{/if}
 	</span>
 {/if}

--- a/src/routes/(shell)/compute/instances/create/+page.svelte
+++ b/src/routes/(shell)/compute/instances/create/+page.svelte
@@ -42,7 +42,11 @@
 	let publicIP = $state(true);
 	let allowedSourceAddresses: Array<string> = $state([]);
 	let flavors = $derived(
-		data.flavors.filter((x) => data.images.some((y) => x.spec.disk >= y.spec.sizeGiB))
+		data.flavors.filter((x) =>
+			data.images.some(
+				(y) => x.spec.disk >= y.spec.sizeGiB && x.spec.architecture === y.spec.architecture
+			)
+		)
 	);
 	$effect.pre(() => {
 		resource.spec.flavorId = flavors[0].metadata.id;
@@ -51,7 +55,11 @@
 		return flavors.find((x) => x.metadata.id == id) as Compute.Flavor;
 	}
 	let images = $derived(
-		data.images.filter((x) => x.spec.sizeGiB <= lookupFlavor(resource.spec.flavorId).spec.disk)
+		data.images.filter(
+			(x) =>
+				x.spec.sizeGiB <= lookupFlavor(resource.spec.flavorId).spec.disk &&
+				x.spec.architecture === lookupFlavor(resource.spec.flavorId).spec.architecture
+		)
 	);
 	function lookupImage(id: string): Compute.Image {
 		return images.find((x) => x.metadata.id == id) as Compute.Image;

--- a/src/routes/(shell)/compute/instances/edit/[id]/+page.svelte
+++ b/src/routes/(shell)/compute/instances/edit/[id]/+page.svelte
@@ -42,7 +42,11 @@
 	let allowedSourceAddresses: Array<string> = $state(initAllowedSourceAddresses());
 	let userData = $state(initUserData());
 	let flavors = $derived(
-		data.flavors.filter((x) => data.images.some((y) => x.spec.disk >= y.spec.sizeGiB))
+		data.flavors.filter((x) =>
+			data.images.some(
+				(y) => x.spec.disk >= y.spec.sizeGiB && x.spec.architecture === y.spec.architecture
+			)
+		)
 	);
 	$effect.pre(() => {
 		resource.spec.flavorId = flavors[0].metadata.id;
@@ -51,7 +55,11 @@
 		return flavors.find((x) => x.metadata.id == id) as Compute.Flavor;
 	}
 	let images = $derived(
-		data.images.filter((x) => x.spec.sizeGiB <= lookupFlavor(resource.spec.flavorId).spec.disk)
+		data.images.filter(
+			(x) =>
+				x.spec.sizeGiB <= lookupFlavor(resource.spec.flavorId).spec.disk &&
+				x.spec.architecture === lookupFlavor(resource.spec.flavorId).spec.architecture
+		)
 	);
 	function lookupImage(id: string): Compute.Image {
 		return images.find((x) => x.metadata.id == id) as Compute.Image;


### PR DESCRIPTION
Flavors now filter to only those with at least one architecturally
compatible image (by both disk size and architecture), and the image
list updates reactively when the flavor changes. Architecture is
displayed in the flavor rich select as `CPU 4× x86_64`, consistent
with the existing GPU multiplier format. GPU sub-properties are
grouped with parentheses for clarity: `GPU 4× B200 (8 logical · 80 GiB)`.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
