### PR TITLE
Implement per-service automated tagging and nightly releases

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,78 @@
+name: Nightly
+on:
+  schedule:
+  - cron: '0 2 * * *'
+  workflow_dispatch: {}
+# Queue concurrent runs rather than cancelling them. cancel-in-progress: true
+# would risk killing a run between image/chart publish and tag push, leaving
+# published artifacts with no corresponding tag.
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+permissions:
+  contents: write
+  packages: write
+env:
+  REGISTRY: ghcr.io
+jobs:
+  Nightly:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Install Helm
+      uses: azure/setup-helm@v4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+    - name: Compute tag
+      run: |
+        TAG="v0.0.0-$(date -u +%Y%m%d%H%M%S)-$(git rev-parse --short=12 HEAD)"
+        CHART_VERSION="${TAG#v}"
+        REPO=$(cut -d'/' -f2 <<< "$GITHUB_REPOSITORY")
+        CHART_NAME=$(sed 's/^uni-//' <<< "$REPO")
+        [[ -d "charts/${CHART_NAME}" ]] || {
+          echo "ERROR: charts/${CHART_NAME} not found — repo name may not match chart directory"
+          exit 1
+        }
+        CHART_PACKAGE_NAME=$(grep '^name:' "charts/${CHART_NAME}/Chart.yaml" | awk '{print $2}')
+        [[ -n "${CHART_PACKAGE_NAME}" ]] || {
+          echo "ERROR: could not extract chart name from charts/${CHART_NAME}/Chart.yaml"
+          exit 1
+        }
+        echo "TAG=${TAG}" >> $GITHUB_ENV
+        echo "CHART_VERSION=${CHART_VERSION}" >> $GITHUB_ENV
+        echo "CHART_NAME=${CHART_NAME}" >> $GITHUB_ENV
+        echo "CHART_PACKAGE_NAME=${CHART_PACKAGE_NAME}" >> $GITHUB_ENV
+    - name: Docker Login
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and Push Image
+      # Nightly images are published under ghcr.io/nscaledev/nightly/ to keep
+      # them segregated from official release images at ghcr.io/nscaledev/.
+      run: make images -e RELEASE=1 VERSION="${TAG}" DOCKER_ORG=ghcr.io/nscaledev/nightly
+    - name: Log in to GHCR (Helm)
+      run: |
+        echo "$GITHUB_TOKEN" | helm registry login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Update chart dependencies
+      run: helm dependency update "charts/${CHART_NAME}"
+    - name: Package and push chart
+      run: |
+        helm package "charts/${CHART_NAME}" --version "${CHART_VERSION}" --app-version "${CHART_VERSION}"
+        helm push "${CHART_PACKAGE_NAME}-${CHART_VERSION}.tgz" "oci://ghcr.io/nscaledev/charts-nightly"
+    # Tag is pushed after successful artifact publishes so a failed publish does
+    # not leave a dangling tag pointing at a commit with no artifacts.
+    - name: Push tag
+      run: |
+        git tag "${TAG}"
+        git push origin "${TAG}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,10 @@ on:
     branches-ignore:
       - '**'
     tags:
-      - '*'
+      # Exclude nightly pseudo-version tags (v0.0.0-*) precisely rather than
+      # using v[1-9]*, which would silently drop legitimate v0.x.y releases.
+      - 'v*'
+      - '!v0.0.0-*'
 permissions:
   contents: write
   packages: write
@@ -14,10 +17,53 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Validate tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          # Strict semver: vX.Y.Z or vX.Y.Z-pre (alphanumeric, dots, hyphens only).
+          # This rejects build metadata (+), path traversal, sed metacharacters, and
+          # anything else that could corrupt the sed interpolation in the patch step.
+          if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$ ]]; then
+            echo "ERROR: tag '${TAG}' is not valid semver (expected vX.Y.Z or vX.Y.Z-pre)"
+            exit 1
+          fi
+          if [[ "${TAG}" == "v0.0.0" || "${TAG}" == v0.0.0-* ]]; then
+            echo "ERROR: tags matching v0.0.0 or v0.0.0-* are reserved for nightly builds"
+            exit 1
+          fi
+      - name: Derive chart version
+        run: |
+          CHART_VERSION="${GITHUB_REF_NAME#v}"
+          REPO=$(cut -d'/' -f2 <<< "$GITHUB_REPOSITORY")
+          CHART_NAME=$(sed 's/^uni-//' <<< "$REPO")
+          [[ -d "charts/${CHART_NAME}" ]] || {
+            echo "ERROR: charts/${CHART_NAME} not found — repo name may not match chart directory"
+            exit 1
+          }
+          echo "CHART_VERSION=${CHART_VERSION}" >> $GITHUB_ENV
+          echo "CHART_NAME=${CHART_NAME}" >> $GITHUB_ENV
+      - name: Patch Chart.yaml sentinel
+        run: |
+          # uni-chart-release-action uses `cr package` which reads version directly
+          # from Chart.yaml and has no --version override flag. The sentinel must be
+          # patched on disk before the action runs. Contrast with nightly.yaml, which
+          # bypasses Chart.yaml entirely via `helm package --version`.
+          sed -i "s/^version: 0\.0\.0$/version: ${CHART_VERSION}/" "charts/${CHART_NAME}/Chart.yaml"
+          sed -i "s/^appVersion: 0\.0\.0$/appVersion: ${CHART_VERSION}/" "charts/${CHART_NAME}/Chart.yaml"
+          PATCHED_VERSION=$(grep '^version:' "charts/${CHART_NAME}/Chart.yaml" | awk '{print $2}')
+          PATCHED_APP_VERSION=$(grep '^appVersion:' "charts/${CHART_NAME}/Chart.yaml" | awk '{print $2}')
+          [[ "${PATCHED_VERSION}" == "${CHART_VERSION}" ]] || {
+            echo "ERROR: Chart.yaml version patch failed — sentinel was not present"
+            exit 1
+          }
+          [[ "${PATCHED_APP_VERSION}" == "${CHART_VERSION}" ]] || {
+            echo "ERROR: Chart.yaml appVersion patch failed — sentinel was not present"
+            exit 1
+          }
       - name: Docker Login
         uses: docker/login-action@v2
         with:

--- a/charts/ui/Chart.yaml
+++ b/charts/ui/Chart.yaml
@@ -4,8 +4,9 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: 1.16.7
-appVersion: 1.16.7
+# sentinel: patched at release time by release.yaml; overridden by --version for nightly builds
+version: 0.0.0
+appVersion: 0.0.0
 
 icon: https://assets.unikorn-cloud.org/assets/images/logos/dark-on-light/icon.png
 


### PR DESCRIPTION
- Add nightly.yaml: daily 2am UTC build that publishes Docker images to
  ghcr.io/nscaledev/nightly/unikorn-ui and Helm charts to
  oci://ghcr.io/nscaledev/charts-nightly, tagged v0.0.0-<timestamp>-<sha>
- Update release.yaml: tighten tag filter to exclude v0.0.0-* nightlies,
  upgrade checkout@v3→v4, add tag validation, derive chart version from
  tag, and patch the Chart.yaml sentinel before running the chart release
  action
- Set Chart.yaml version/appVersion to 0.0.0 sentinel; real versions are
  injected at build time rather than committed

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
