### PR TITLE
Add Slack failure notification to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -76,3 +76,13 @@ jobs:
       run: |
         git tag "${TAG}"
         git push origin "${TAG}"
+    - name: Notify Slack on failure
+      if: failure()
+      uses: slackapi/slack-github-action@v2
+      with:
+        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+        webhook-type: incoming-webhook
+        payload: |
+          {
+            "text": ":red_circle: *Nightly build failed* — `${{ github.repository }}`. I'll be back.\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }


### PR DESCRIPTION
Posts to the configured SLACK_WEBHOOK_URL channel when any step fails,
including a link to the failed run.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
