### PR TITLE
fix: surface health error chip when instance is provisioned but unhealthy

### DIFF
--- a/src/lib/layouts/effectiveStatus.test.ts
+++ b/src/lib/layouts/effectiveStatus.test.ts
@@ -59,6 +59,19 @@ describe('resolveChip', () => {
 		const op = { label: 'running', chipClass: 'ok' as const };
 		expect(resolveChip('error' as never, op)).toEqual({ label: 'error', chipClass: 'err' });
 	});
+
+	it('returns error chip when provisioned but healthStatus is error', () => {
+		const op = { label: 'pending', chipClass: 'info' as const };
+		expect(resolveChip('provisioned' as never, op, 'error' as never)).toEqual({
+			label: 'error',
+			chipClass: 'err'
+		});
+	});
+
+	it('returns operational status when provisioned and healthStatus is not error', () => {
+		const op = { label: 'running', chipClass: 'ok' as const };
+		expect(resolveChip('provisioned' as never, op, 'healthy' as never)).toEqual(op);
+	});
 });
 
 describe('fromPowerState', () => {

--- a/src/lib/layouts/effectiveStatus.ts
+++ b/src/lib/layouts/effectiveStatus.ts
@@ -13,14 +13,16 @@ export interface OperationalStatus {
  * Resolve the single effective status chip for a resource card.
  *
  * Priority:
- *   unknown / undefined  → null (suppress chip)
- *   error                → error chip
- *   provisioning states  → provisioning lifecycle chip
- *   provisioned          → operationalStatus if provided, else "provisioned"
+ *   unknown / undefined          → null (suppress chip)
+ *   error provisioningStatus     → error chip
+ *   provisioning states          → provisioning lifecycle chip
+ *   provisioned + error health   → error chip (e.g. Nova scheduling failure)
+ *   provisioned                  → operationalStatus if provided, else "provisioned"
  */
 export function resolveChip(
 	provisioningStatus: Identity.ResourceProvisioningStatus | undefined,
-	operationalStatus: OperationalStatus | null | undefined
+	operationalStatus: OperationalStatus | null | undefined,
+	healthStatus?: Identity.ResourceHealthStatus
 ): { label: string; chipClass: ChipClass } | null {
 	switch (provisioningStatus) {
 		case Identity.ResourceProvisioningStatus.Unknown:
@@ -35,6 +37,8 @@ export function resolveChip(
 		case Identity.ResourceProvisioningStatus.Deprovisioning:
 			return { label: 'deprovisioning', chipClass: 'warn' };
 		case Identity.ResourceProvisioningStatus.Provisioned:
+			if (healthStatus === Identity.ResourceHealthStatus.Error)
+				return { label: 'error', chipClass: 'err' };
 			return operationalStatus ?? { label: 'provisioned', chipClass: 'ok' };
 		default:
 			return { label: provisioningStatus, chipClass: 'muted' };

--- a/src/routes/(shell)/compute/instances/+page.svelte
+++ b/src/routes/(shell)/compute/instances/+page.svelte
@@ -140,7 +140,8 @@
 	{#snippet tableRow(resource)}
 		{@const chip = resolveChip(
 			resource.metadata.provisioningStatus,
-			fromPowerState(resource.status.powerState)
+			fromPowerState(resource.status.powerState),
+			resource.metadata.healthStatus
 		)}
 		{@const proj = instanceProject(resource)}
 		<td class="primary">


### PR DESCRIPTION
Passes healthStatus to resolveChip so a provisioned instance with a
health error (e.g. Nova scheduling failure) shows an error chip rather
than the operational/power-state chip.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
