### PR TITLE
feat: render Queued and Building instance lifecycle phases

### DIFF
--- a/src/lib/layouts/effectiveStatus.ts
+++ b/src/lib/layouts/effectiveStatus.ts
@@ -58,6 +58,10 @@ export function fromPowerState(
 			return { label: 'stopping', chipClass: 'warn' };
 		case Compute.InstanceLifecyclePhase.Pending:
 			return { label: 'pending', chipClass: 'info' };
+		case Compute.InstanceLifecyclePhase.Queued:
+			return { label: 'queued', chipClass: 'info' };
+		case Compute.InstanceLifecyclePhase.Building:
+			return { label: 'building', chipClass: 'info' };
 		default:
 			return null;
 	}

--- a/src/lib/openapi/compute/models/InstanceLifecyclePhase.ts
+++ b/src/lib/openapi/compute/models/InstanceLifecyclePhase.ts
@@ -19,6 +19,8 @@
  */
 export const InstanceLifecyclePhase = {
     Pending: 'Pending',
+    Queued: 'Queued',
+    Building: 'Building',
     Running: 'Running',
     Stopping: 'Stopping',
     Stopped: 'Stopped'

--- a/src/lib/openapi/region/models/InstanceLifecyclePhase.ts
+++ b/src/lib/openapi/region/models/InstanceLifecyclePhase.ts
@@ -19,6 +19,8 @@
  */
 export const InstanceLifecyclePhase = {
     Pending: 'Pending',
+    Queued: 'Queued',
+    Building: 'Building',
     Running: 'Running',
     Stopping: 'Stopping',
     Stopped: 'Stopped'


### PR DESCRIPTION
## Summary

The region service is starting to report two new \`InstanceLifecyclePhase\` values during instance create — \`Queued\` (Nova has bound an Ironic node but Ironic hasn't started the deploy yet, mostly baremetal) and \`Building\` (Ironic is actively deploying or Nova is mid-build). Without UI support, the response decode fails on the new values and the status chip silently disappears (or never updates from \"Pending\") for the entire deploy window.

This PR:

- Adds \`Queued\` and \`Building\` to the openapi-generated \`InstanceLifecyclePhase\` constants in both \`compute\` and \`region\` model packages, so response decoding accepts the new values.
- Adds matching cases to \`fromPowerState\` so each phase renders as an info-colored chip with a sensible label (\`queued\`, \`building\`).

The fallback paths in \`machineStatus/index.ts\` (icon, color, can-stop/start/reboot) already do the right thing for the new phases without needing explicit cases: spinner icon, muted color, no stop/start/reboot allowed.

## Why patch the generated files by hand

The OpenAPI generator pulls the schema from the \`main\` branches of \`unikorn-cloud/compute\` and \`unikorn-cloud/region\`. Once those repos land their INST-921 changes, re-running \`npm run openapi:compute && npm run openapi:region\` will emit the same constants. Patching by hand avoids gating the chip work on the upstream releases.

## Stack

This depends on the upstream region + compute changes for the new phases to actually arrive from the API:

- [region#562 (or successor)](https://github.com/nscaledev/uni-region) — add \`Queued\` / \`Building\` to \`instanceLifecyclePhase\` enum + monitor mapping
- [compute#299](https://github.com/nscaledev/uni-compute/pull/299) — propagate phases through compute API

Once both land, the openapi specs can be regenerated and this PR's hand-patches will match the generator output exactly.

## Test plan

End-to-end verified against a local Tilt dev environment + remote devstack:

- [x] Provisioned a baremetal instance with a synthetic delay between Nova's \`set_instance_uuid\` and \`set_provision_state(active)\` — UI chip showed \"queued\" for the duration of the bound-but-undeployed window, then transitioned to \"running\".
- [x] Existing Pending / Running / Stopping / Stopped flows unchanged.
- [x] \`npm run check\` — no new errors.
- [x] \`npm run lint\` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)