### PR TITLE
fix: portal and align MultiSelect dropdown

### DIFF
--- a/src/lib/forms/MultiSelect.svelte
+++ b/src/lib/forms/MultiSelect.svelte
@@ -72,17 +72,19 @@
 				/>
 			</div>
 
-			<Combobox.Content class="menu ms-menu" sideOffset={4}>
-				{#if available.length}
-					{#each available as option}
-						<Combobox.Item value={option.value} label={option.label} class="menu__item">
-							{option.label}
-						</Combobox.Item>
-					{/each}
-				{:else}
-					<div class="ms-empty">No options</div>
-				{/if}
-			</Combobox.Content>
+			<Combobox.Portal>
+				<Combobox.Content class="menu ms-menu" sideOffset={4} align="start">
+					{#if available.length}
+						{#each available as option}
+							<Combobox.Item value={option.value} label={option.label} class="menu__item">
+								{option.label}
+							</Combobox.Item>
+						{/each}
+					{:else}
+						<div class="ms-empty">No options</div>
+					{/if}
+				</Combobox.Content>
+			</Combobox.Portal>
 		</Combobox.Root>
 	</div>
 </div>
@@ -177,10 +179,10 @@
 
 	/* Dropdown */
 	:global(.ms-menu) {
-		width: var(--bits-combobox-content-available-width, 100%);
+		width: var(--bits-floating-anchor-width);
 		max-height: 240px;
 		overflow-y: auto;
-		z-index: 50;
+		z-index: 200;
 	}
 
 	.ms-empty {


### PR DESCRIPTION
The MultiSelect combobox rendered its options popup inline, trapping it in
the form's stacking/overflow context so it layered under other elements, and
left it centered on rather than aligned to the input.

Wrap Combobox.Content in Combobox.Portal so it renders to the body, add
align="start" to left-align with the input, and use --bits-floating-anchor-width
(the nonexistent --bits-combobox-content-available-width silently fell back to
100%) so the popup matches the trigger width.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
