### PR TITLE
Bump nanoid from 3.3.16 to 3.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4818,9 +4818,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"funding": [
 				{
 					"type": "github",


### PR DESCRIPTION
Fixes GHSA-2v37-7h3g-55p8 (CVE-2026-67213): customAlphabet and
customRandom loop forever when called with a size of 0.

nanoid is a transitive dependency, pulled in by postcss via vite,
eslint-plugin-svelte and autoprefixer. Dependabot could not raise this
itself as there is no top-level package to bump, but postcss already
asks for ^3.3.16 so the patched version drops straight in with a
lockfile refresh.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
